### PR TITLE
Feature/single node multi writer support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/dell/csi-powerstore
 
 go 1.16
 
+// update gocsi to v1.5 post release
+
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect
 	github.com/akutz/gosync v0.1.0

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -577,7 +577,12 @@ func (s *Service) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valid
 			supported = false
 			reason = ErrUnknownAccessMode
 			break
+		// SINGLE_NODE_WRITER to be deprecated in future
 		case csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER:
+			break
+		case csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER:
+			break
+		case csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER:
 			break
 		case csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY:
 			break

--- a/pkg/controller/publisher.go
+++ b/pkg/controller/publisher.go
@@ -105,7 +105,9 @@ func (s *SCSIPublisher) Publish(ctx context.Context, req *csi.ControllerPublishV
 	if mappingCount != 0 {
 		switch req.VolumeCapability.AccessMode.Mode {
 		case csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-			csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY:
+			csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+			csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
+			csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER:
 			log.Error(fmt.Sprintf(
 				"ControllerPublishVolume: Volume present in a different lun mapping - '%s'",
 				mapping[0].HostID))

--- a/pkg/node/publisher.go
+++ b/pkg/node/publisher.go
@@ -41,7 +41,7 @@ type SCSIPublisher struct {
 
 // Publish publishes volume as either raw block or mount by mounting it to the target path
 func (sp *SCSIPublisher) Publish(ctx context.Context, logFields log.Fields, fs fs.Interface, cap *csi.VolumeCapability, isRO bool, targetPath string, stagingPath string) (*csi.NodePublishVolumeResponse, error) {
-	published, err := isAlreadyPublished(ctx, targetPath, getRWModeString(isRO), fs)
+	published, err := isAlreadyPublished(ctx, targetPath, stagingPath, getRWModeString(isRO), fs, cap)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ type NFSPublisher struct {
 // Publish publishes nfs volume by mounting it to the target path
 func (np *NFSPublisher) Publish(ctx context.Context, logFields log.Fields, fs fs.Interface,
 	cap *csi.VolumeCapability, isRO bool, targetPath string, stagingPath string) (*csi.NodePublishVolumeResponse, error) {
-	published, err := isAlreadyPublished(ctx, targetPath, getRWModeString(isRO), fs)
+	published, err := isAlreadyPublished(ctx, targetPath, stagingPath, getRWModeString(isRO), fs, cap)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description
Changes to return error when more than one pods are trying to mount a volume with SINGLE NODE SINGLE WRITER access mode (RWOP)

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| Issue 80 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Tested with Kubernetes cluster v1.22 and 1.21
- [ ] Test creating multiple pods with the same volume on the same node
