### PR TITLE
added BDD unit tests for replication methods

### DIFF
--- a/pkg/controller/replication_test.go
+++ b/pkg/controller/replication_test.go
@@ -2,14 +2,17 @@ package controller_test
 
 import (
 	"context"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
+	"github.com/dell/csi-powerstore/pkg/array"
+	"github.com/dell/csi-powerstore/pkg/controller"
 	csiext "github.com/dell/dell-csi-extensions/replication"
 	"github.com/dell/gopowerstore"
+	"github.com/dell/gopowerstore/api"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"net/http"
 )
 
 var _ = Describe("Replication", func() {
@@ -310,5 +313,668 @@ var _ = Describe("Replication", func() {
 				)
 			})
 		})
+	})
+	Describe("calling ExecuteAction()", func() {
+		When("action is RS_ACTION_RESUME and state is OK", func() {
+			It("return nil", func() {
+				clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+				session := gopowerstore.ReplicationSession{ID: "test", State: "OK"}
+				action := gopowerstore.RS_ACTION_RESUME
+				failoverParams := gopowerstore.FailoverParams{}
+				err := controller.ExecuteAction(&session, clientMock, action, &failoverParams)
+
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("action is RS_ACTION_REPROTECT and state is not OK", func() {
+			It("return nil", func() {
+				clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+				session := gopowerstore.ReplicationSession{ID: "test", State: "OK"}
+				action := gopowerstore.RS_ACTION_REPROTECT
+				failoverParams := gopowerstore.FailoverParams{}
+				err := controller.ExecuteAction(&session, clientMock, action, &failoverParams)
+
+				Expect(err).To(BeNil())
+
+			})
+		})
+
+		When("action is RS_ACTION_PAUSE and state is Paused", func() {
+			It("return nil", func() {
+				clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+				session := gopowerstore.ReplicationSession{ID: "test", State: "Paused"}
+				action := gopowerstore.RS_ACTION_PAUSE
+				failoverParams := gopowerstore.FailoverParams{}
+				err := controller.ExecuteAction(&session, clientMock, action, &failoverParams)
+
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("action is RS_ACTION_FAILOVER and state is Failing_Over", func() {
+			It("return nil", func() {
+				clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+				session := gopowerstore.ReplicationSession{ID: "test", State: "Failing_Over"}
+				action := gopowerstore.RS_ACTION_FAILOVER
+				failoverParams := gopowerstore.FailoverParams{}
+				err := controller.ExecuteAction(&session, clientMock, action, &failoverParams)
+
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(
+					ContainSubstring("Execute action: RS (test) is still executing previous action"))
+
+			})
+		})
+
+		When("action is RS_ACTION_FAILOVER and state is Failed_Over", func() {
+			It("return nil", func() {
+				clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+				session := gopowerstore.ReplicationSession{ID: "test", State: "Failed_Over"}
+				action := gopowerstore.RS_ACTION_FAILOVER
+				failoverParams := gopowerstore.FailoverParams{}
+				err := controller.ExecuteAction(&session, clientMock, action, &failoverParams)
+
+				Expect(err).To(BeNil())
+
+			})
+
+		})
+		Describe("calling DeleteStorageProtectionGroup()", func() {
+			When("GlobalID is missing", func() {
+				It("should fail", func() {
+					req := new(csiext.DeleteStorageProtectionGroupRequest)
+					res, err := ctrlSvc.DeleteStorageProtectionGroup(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("missing globalID in protection group attributes"))
+				})
+			})
+			When("Array with specified globalID couldn't be found", func() {
+				It("should fail", func() {
+
+					req := new(csiext.DeleteStorageProtectionGroupRequest)
+					params := make(map[string]string)
+					params["globalID"] = "SOMETHING WRONG"
+					req.ProtectionGroupAttributes = params
+					res, err := ctrlSvc.DeleteStorageProtectionGroup(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("can't find array with global id"))
+				})
+			})
+			When("can't get volume group", func() {
+				It("should fail", func() {
+					clientMock.On("GetVolumeGroup", mock.Anything, mock.Anything).Return(
+
+						gopowerstore.VolumeGroup{}, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusBadRequest}})
+					req := new(csiext.DeleteStorageProtectionGroupRequest)
+					params := make(map[string]string)
+
+					params["globalID"] = firstValidID
+
+					req.ProtectionGroupAttributes = params
+
+					res, err := ctrlSvc.DeleteStorageProtectionGroup(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Error: Unable to get Volume Group"))
+				})
+			})
+			When("can't get volume group name", func() {
+				It("should fail", func() {
+					clientMock.On("GetVolumeGroup", mock.Anything, mock.Anything).Return(
+						gopowerstore.VolumeGroup{}, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					req := new(csiext.DeleteStorageProtectionGroupRequest)
+					params := make(map[string]string)
+
+					params["globalID"] = firstValidID
+
+					req.ProtectionGroupAttributes = params
+
+					res, err := ctrlSvc.DeleteStorageProtectionGroup(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Error: Unable to get volume group name"))
+				})
+			})
+			When("Can't unassign the protection policy from volume group", func() {
+				It("should fail", func() {
+					vg := gopowerstore.VolumeGroup{}
+					vg.ProtectionPolicyID = validPolicyID
+					vg.ID = validGroupID
+					clientMock.On("GetVolumeGroup", mock.Anything, mock.Anything).Return(
+						vg, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("ModifyVolumeGroup", mock.Anything, mock.Anything, mock.Anything).Return(
+						gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusBadRequest}})
+
+					req := new(csiext.DeleteStorageProtectionGroupRequest)
+					params := make(map[string]string)
+
+					params["globalID"] = firstValidID
+
+					req.ProtectionGroupAttributes = params
+
+					res, err := ctrlSvc.DeleteStorageProtectionGroup(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Error: Unable to un-assign PP from Volume Group"))
+				})
+			})
+			When("Can't delete volume group", func() {
+				It("should fail", func() {
+					vg := gopowerstore.VolumeGroup{}
+					vg.ProtectionPolicyID = ""
+					vg.ID = validGroupID
+					clientMock.On("GetVolumeGroup", mock.Anything, mock.Anything).Return(
+						vg, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("DeleteVolumeGroup", mock.Anything, mock.Anything).Return(
+						gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusBadRequest}})
+
+					req := new(csiext.DeleteStorageProtectionGroupRequest)
+					params := make(map[string]string)
+
+					params["globalID"] = firstValidID
+
+					req.ProtectionGroupAttributes = params
+					res, err := ctrlSvc.DeleteStorageProtectionGroup(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Error: : Unable to delete Volume Group"))
+				})
+			})
+			When("Can't get the protection policy", func() {
+				It("should fail", func() {
+					vg := gopowerstore.VolumeGroup{}
+					vg.ProtectionPolicyID = validPolicyID
+					vg.ID = validGroupID
+					vg.Name = validGroupName
+					pp := gopowerstore.ProtectionPolicy{}
+					pp.Name = validPolicyName
+
+					clientMock.On("GetVolumeGroup", mock.Anything, mock.Anything).Return(
+						vg, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("GetProtectionPolicyByName", mock.Anything, mock.Anything).Return(
+						gopowerstore.ProtectionPolicy{}, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusBadRequest}})
+					clientMock.On("ModifyVolumeGroup", mock.Anything, mock.Anything, mock.Anything).Return(
+						gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("DeleteVolumeGroup", mock.Anything, mock.Anything).Return(
+						gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("GetReplicationRuleByName", mock.Anything, mock.Anything).Return(
+						gopowerstore.ReplicationRule{}, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+
+					req := new(csiext.DeleteStorageProtectionGroupRequest)
+					params := make(map[string]string)
+
+					params["globalID"] = firstValidID
+					params["VolumeGroupName"] = validGroupName
+
+					req.ProtectionGroupAttributes = params
+					res, err := ctrlSvc.DeleteStorageProtectionGroup(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Error: Unable to get the PP"))
+				})
+			})
+
+			When("The replication rule couldn't be found", func() {
+				It("should fail", func() {
+					vg := gopowerstore.VolumeGroup{}
+					vg.ProtectionPolicyID = validPolicyID
+					vg.ID = validGroupID
+					vg.Name = validGroupName
+					pp := gopowerstore.ProtectionPolicy{}
+					pp.Name = validPolicyName
+					rr := gopowerstore.ReplicationRule{}
+					rr.Name = validRuleName
+
+					clientMock.On("GetVolumeGroup", mock.Anything, mock.Anything).Return(
+						vg, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("GetProtectionPolicyByName", mock.Anything, mock.Anything).Return(
+						gopowerstore.ProtectionPolicy{}, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("ModifyVolumeGroup", mock.Anything, mock.Anything, mock.Anything).Return(
+						gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("DeleteVolumeGroup", mock.Anything, mock.Anything).Return(
+						gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("GetReplicationRuleByName", mock.Anything, mock.Anything).Return(
+						rr, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusBadRequest}})
+
+					req := new(csiext.DeleteStorageProtectionGroupRequest)
+					params := make(map[string]string)
+
+					params["globalID"] = firstValidID
+					params["VolumeGroupName"] = validGroupName
+
+					req.ProtectionGroupAttributes = params
+					res, err := ctrlSvc.DeleteStorageProtectionGroup(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Error: RR not found"))
+				})
+			})
+			When("The replication rule can't be deleted", func() {
+				It("should fail", func() {
+					vg := gopowerstore.VolumeGroup{}
+					vg.ProtectionPolicyID = validPolicyID
+					vg.ID = validGroupID
+					vg.Name = validGroupName
+					pp := gopowerstore.ProtectionPolicy{}
+					pp.Name = validPolicyName
+					rr := gopowerstore.ReplicationRule{}
+					rr.Name = validRuleName
+					rr.ID = validRuleID
+
+					clientMock.On("GetVolumeGroup", mock.Anything, mock.Anything).Return(
+						vg, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("GetProtectionPolicyByName", mock.Anything, mock.Anything).Return(
+						gopowerstore.ProtectionPolicy{}, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("ModifyVolumeGroup", mock.Anything, mock.Anything, mock.Anything).Return(
+						gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("DeleteVolumeGroup", mock.Anything, mock.Anything).Return(
+						gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("GetReplicationRuleByName", mock.Anything, mock.Anything).Return(
+						rr, gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("DeleteReplicationRule", mock.Anything, mock.Anything).Return(
+						gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusBadRequest}})
+
+					req := new(csiext.DeleteStorageProtectionGroupRequest)
+					params := make(map[string]string)
+
+					params["globalID"] = firstValidID
+					params["VolumeGroupName"] = validGroupName
+
+					req.ProtectionGroupAttributes = params
+
+					res, err := ctrlSvc.DeleteStorageProtectionGroup(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Error: Unable to delete replication rule"))
+				})
+			})
+		})
+		Describe("calling GetReplicationCapabilities()", func() {
+			When("basic parameters are declared", func() {
+				It("should pass", func() {
+					context := context.Background()
+					req := new(csiext.GetReplicationCapabilityRequest)
+					var rep = new(csiext.GetReplicationCapabilityResponse)
+					rep.Capabilities = []*csiext.ReplicationCapability{
+						{
+							Type: &csiext.ReplicationCapability_Rpc{
+								Rpc: &csiext.ReplicationCapability_RPC{
+									Type: csiext.ReplicationCapability_RPC_CREATE_REMOTE_VOLUME,
+								},
+							},
+						},
+						{
+							Type: &csiext.ReplicationCapability_Rpc{
+								Rpc: &csiext.ReplicationCapability_RPC{
+									Type: csiext.ReplicationCapability_RPC_CREATE_PROTECTION_GROUP,
+								},
+							},
+						},
+						{
+							Type: &csiext.ReplicationCapability_Rpc{
+								Rpc: &csiext.ReplicationCapability_RPC{
+									Type: csiext.ReplicationCapability_RPC_DELETE_PROTECTION_GROUP,
+								},
+							},
+						},
+						{
+							Type: &csiext.ReplicationCapability_Rpc{
+								Rpc: &csiext.ReplicationCapability_RPC{
+									Type: csiext.ReplicationCapability_RPC_REPLICATION_ACTION_EXECUTION,
+								},
+							},
+						},
+						{
+							Type: &csiext.ReplicationCapability_Rpc{
+								Rpc: &csiext.ReplicationCapability_RPC{
+									Type: csiext.ReplicationCapability_RPC_MONITOR_PROTECTION_GROUP,
+								},
+							},
+						},
+					}
+					rep.Actions = []*csiext.SupportedActions{
+						{
+							Actions: &csiext.SupportedActions_Type{
+								Type: csiext.ActionTypes_FAILOVER_REMOTE,
+							},
+						},
+						{
+							Actions: &csiext.SupportedActions_Type{
+								Type: csiext.ActionTypes_UNPLANNED_FAILOVER_LOCAL,
+							},
+						},
+						{
+							Actions: &csiext.SupportedActions_Type{
+								Type: csiext.ActionTypes_REPROTECT_LOCAL,
+							},
+						},
+						{
+							Actions: &csiext.SupportedActions_Type{
+								Type: csiext.ActionTypes_SUSPEND,
+							},
+						},
+						{
+							Actions: &csiext.SupportedActions_Type{
+								Type: csiext.ActionTypes_RESUME,
+							},
+						},
+						{
+							Actions: &csiext.SupportedActions_Type{
+								Type: csiext.ActionTypes_SYNC,
+							},
+						},
+					}
+					res, err := ctrlSvc.GetReplicationCapabilities(context, req)
+					Expect(err).To(BeNil())
+					Expect(res).To(Equal(rep))
+
+				})
+			})
+		})
+
+		Describe("calling ExecuteAction()", func() {
+			When("action is unknown", func() {
+				It("should fail", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_UNKNOWN_ACTION,
+					}
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       nil,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+					Expect(err).NotTo(BeNil())
+
+				})
+			})
+			When("Array can't be found", func() {
+				It("should fail", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_FAILOVER_REMOTE,
+					}
+					clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+					clientMock.On("ExecuteAction", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(status.Errorf(codes.Internal, "Execute action: Failed to modify RS (%s) - Error (%s)", "123", "12"))
+					ctrlSvc.SetArrays(map[string]*array.PowerStoreArray{})
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       params,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("can't find array with global id "))
+
+				})
+			})
+			When("the action is not supported", func() {
+				It("should fail", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_UNKNOWN_ACTION,
+					}
+					clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+					clientMock.On("GetReplicationSessionByLocalResourceID", mock.Anything, mock.Anything).Return(gopowerstore.ReplicationSession{}, status.Errorf(codes.Unknown, "The requested action does not match with supported actions"))
+
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       params,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("The requested action does not match with supported actions"))
+
+				})
+			})
+
+			When("the replication session is executing previous action. the action type is unplanned failover local", func() {
+				It("should fail", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_UNPLANNED_FAILOVER_LOCAL,
+					}
+					session := gopowerstore.ReplicationSession{ID: "test", State: "Failing_Over"}
+
+					clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("GetReplicationSessionByLocalResourceID", mock.Anything, mock.Anything).Return(session, nil)
+
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       params,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Execute action: RS (test) is still executing previous action"))
+
+				})
+			})
+			When("the action type is suspend", func() {
+				It("pass", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_SUSPEND,
+					}
+					session := gopowerstore.ReplicationSession{ID: "test", State: "Failing_Over"}
+
+					clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gopowerstore.EmptyResponse(""), nil)
+					clientMock.On("GetReplicationSessionByLocalResourceID", mock.Anything, mock.Anything).Return(session, nil)
+
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       params,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+
+					Expect(err).To(BeNil())
+
+				})
+			})
+			When("the replication session is executing previous action. the action type is failover remote.", func() {
+				It("should fail", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_FAILOVER_REMOTE,
+					}
+					session := gopowerstore.ReplicationSession{ID: "test", State: "Failing_Over"}
+
+					clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+					clientMock.On("GetReplicationSessionByLocalResourceID", mock.Anything, mock.Anything).Return(session, nil)
+
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       params,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Execute action: RS (test) is still executing previous action"))
+
+				})
+			})
+			When("the replication session can't be modified due to sync action type.", func() {
+				It("should fail", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_SYNC,
+					}
+					session := gopowerstore.ReplicationSession{ID: "test", State: "Failed_Over"}
+
+					clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gopowerstore.EmptyResponse(""), gopowerstore.APIError{ErrorMsg: &api.ErrorMsg{StatusCode: http.StatusNotFound}})
+					clientMock.On("GetReplicationSessionByLocalResourceID", mock.Anything, mock.Anything).Return(session, nil)
+
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       params,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("Execute action: Failed to modify RS (test) - Error ()"))
+
+				})
+			})
+			When("the action type is resume", func() {
+				It("should pass", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_RESUME,
+					}
+					session := gopowerstore.ReplicationSession{ID: "test", State: "Failing_Over"}
+
+					clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gopowerstore.EmptyResponse(""), nil)
+					clientMock.On("GetReplicationSessionByLocalResourceID", mock.Anything, mock.Anything).Return(session, nil)
+
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       params,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+
+					Expect(err).To(BeNil())
+
+				})
+			})
+			When("the action type is sync", func() {
+				It("should pass", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_SYNC,
+					}
+					session := gopowerstore.ReplicationSession{ID: "test", State: "Failing_Over"}
+
+					clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gopowerstore.EmptyResponse(""), nil)
+					clientMock.On("GetReplicationSessionByLocalResourceID", mock.Anything, mock.Anything).Return(session, nil)
+
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       params,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+
+					Expect(err).To(BeNil())
+
+				})
+			})
+			When("the action type is reprotect local", func() {
+				It("should pass", func() {
+
+					action := &csiext.Action{
+						ActionTypes: csiext.ActionTypes_REPROTECT_LOCAL,
+					}
+					session := gopowerstore.ReplicationSession{ID: "test", State: "Failing_Over"}
+
+					clientMock.On("ExecuteActionOnReplicationSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gopowerstore.EmptyResponse(""), nil)
+					clientMock.On("GetReplicationSessionByLocalResourceID", mock.Anything, mock.Anything).Return(session, nil)
+
+					params := make(map[string]string)
+					params["globalID"] = "globalvolid1"
+
+					req := &csiext.ExecuteActionRequest{
+						ActionId:                        "",
+						ProtectionGroupId:               "",
+						ActionTypes:                     &csiext.ExecuteActionRequest_Action{Action: action},
+						ProtectionGroupAttributes:       params,
+						RemoteProtectionGroupId:         "",
+						RemoteProtectionGroupAttributes: nil,
+					}
+					_, err := ctrlSvc.ExecuteAction(context.Background(), req)
+
+					Expect(err).To(BeNil())
+
+				})
+			})
+
+		})
+
 	})
 })


### PR DESCRIPTION
# Description
This Pull Request adds numerous BDD unit tests for the replication part of the driver, testing such gRPC methods as `CreateRemoteVolume`, `CreateStorageProtectionGroup`, `ExecuteAction` and others 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| Technical debt |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How this was tested
- [x] Unit Tests
go clean -cache; cd ./pkg; go test -race -cover -coverprofile=coverage.out -coverpkg ./... ./...
ok      github.com/dell/csi-powerstore/pkg/array        0.199s  coverage: 3.3% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/common       0.133s  coverage: 1.3% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/common/fs    0.287s  coverage: 1.0% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/controller   1.383s  coverage: 43.0% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/identity     0.301s  coverage: 0.2% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/interceptors 2.942s  coverage: 1.9% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/node 1.019s  coverage: 39.0% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/tracer       0.143s  coverage: 0.2% of statements in ./...

Total coverage 90.1%
