### PR TITLE
make volume health monitor optional and bugfix/krv-1489

### DIFF
--- a/helm/csi-powerstore/templates/controller.yaml
+++ b/helm/csi-powerstore/templates/controller.yaml
@@ -233,6 +233,8 @@ spec:
               mountPath: /powerstore-config-params
         {{- end }}
         {{- end }}
+        {{- if hasKey .Values.controller "healthMonitor" }}
+        {{- if eq .Values.controller.healthMonitor.enabled true}}
         - name: csi-external-health-monitor-controller
           image: {{ required "Must provide the CSI external health monitor controller image." .Values.images.externalhealthmonitorcontroller}}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -242,7 +244,7 @@ spec:
             - "--leader-election"
             - "--http-endpoint=:8080"
             - "--enable-node-watcher=true"
-            - "--monitor-interval={{ .Values.volumeHealthMonitorInterval | default "60s" }}"
+            - "--monitor-interval={{ .Values.controller.healthMonitor.volumeHealthMonitorInterval | default "60s" }}"
             - "--timeout=180s"
           env:
             - name: ADDRESS
@@ -250,6 +252,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
+        {{- end }}
+        {{- end }}
         - name: driver
           image: {{ required "Must provide the PowerStore driver container image." .Values.images.driver }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -278,6 +282,12 @@ spec:
               value: {{ .Values.controller.replication.replicationContextPrefix | default "powerstore"}}
             - name: X_CSI_REPLICATION_PREFIX
               value: {{ .Values.controller.replication.replicationPrefix | default "replication.storage.dell.com"}}
+            {{- end }}
+            {{- end }}
+            {{- if hasKey .Values.controller "healthMonitor" }}
+            {{- if eq .Values.controller.healthMonitor.enabled true}}
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "{{ .Values.controller.healthMonitor.enabled }}"
             {{- end }}
             {{- end }}
             - name: GOPOWERSTORE_DEBUG

--- a/helm/csi-powerstore/values.yaml
+++ b/helm/csi-powerstore/values.yaml
@@ -34,12 +34,6 @@ externalAccess:
 # Default value: None
 imagePullPolicy: IfNotPresent
 
-# healthMonitorInterval: Interval of monitoring volume health condition
-# Allowed values: Number followed by unit (s,m,h)
-# Examples: 60s, 5m, 1h
-# Default value: 60s
-volumeHealthMonitorInterval: 60s
-
 # controller: configure controller specific parameters
 controller:
   # controllerCount: defines the number of csi-powerscale controller pods to deploy to
@@ -75,6 +69,20 @@ controller:
     #   false: disable volume expansion feature(do not install resizer sidecar)
     # Default value: None
     enabled: true
+
+  healthMonitor:
+    # enabled: Enable/Disable health monitor of CSI volumes
+    # Allowed values:
+    #   true: enable checking of health condition of CSI volumes
+    #   false: disable checking of health condition of CSI volumes
+    # Default value: None
+    enabled: false
+    
+    # healthMonitorInterval: Interval of monitoring volume health condition
+    # Allowed values: Number followed by unit (s,m,h)
+    # Examples: 60s, 5m, 1h
+    # Default value: 60s
+    volumeHealthMonitorInterval: 60s
 
   # replication: allows to configure replication
   # Replication CRDs must be installed before installing driver

--- a/pkg/common/envvars.go
+++ b/pkg/common/envvars.go
@@ -79,4 +79,7 @@ const (
 
 	// EnvGOCSIDebug indicates whether to print REQUESTs and RESPONSEs of all CSI method calls(from gocsi)
 	EnvGOCSIDebug = "X_CSI_DEBUG"
+
+	// EnvIsHealthMonitorEnabled specifies if health monitor is enabled.
+	EnvIsHealthMonitorEnabled = "X_CSI_HEALTH_MONITOR_ENABLED"
 )

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2825,8 +2825,10 @@ var _ = Describe("CSIControllerService", func() {
 	})
 
 	Describe("calling ControllerGetCapabilities()", func() {
-		When("plugin functions correctly", func() {
+		When("plugin functions correctly with health monitor capabilities", func() {
 			It("should return supported capabilities", func() {
+				csictx.Setenv(context.Background(), common.EnvIsHealthMonitorEnabled, "true")
+				ctrlSvc.Init()
 				res, err := ctrlSvc.ControllerGetCapabilities(context.Background(), &csi.ControllerGetCapabilitiesRequest{})
 				Expect(err).To(BeNil())
 				Expect(res).To(Equal(&csi.ControllerGetCapabilitiesResponse{
@@ -2898,6 +2900,67 @@ var _ = Describe("CSIControllerService", func() {
 							Type: &csi.ControllerServiceCapability_Rpc{
 								Rpc: &csi.ControllerServiceCapability_RPC{
 									Type: csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
+								},
+							},
+						},
+					},
+				}))
+			})
+		})
+		When("plugin functions correctly without health monitor capabilities", func() {
+			It("should return supported capabilities", func() {
+				csictx.Setenv(context.Background(), common.EnvIsHealthMonitorEnabled, "false")
+				ctrlSvc.Init()
+				res, err := ctrlSvc.ControllerGetCapabilities(context.Background(), &csi.ControllerGetCapabilitiesRequest{})
+				Expect(err).To(BeNil())
+				Expect(res).To(Equal(&csi.ControllerGetCapabilitiesResponse{
+					Capabilities: []*csi.ControllerServiceCapability{
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+								},
+							},
+						},
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+								},
+							},
+						},
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_GET_CAPACITY,
+								},
+							},
+						},
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
+								},
+							},
+						},
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
+								},
+							},
+						},
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
+								},
+							},
+						},
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 								},
 							},
 						},


### PR DESCRIPTION
# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/73 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit Test
- [x] Test in k8s cluster

Test Results:
[csi-powerstore]# make test
go clean -cache; cd ./pkg; go test -race -cover -coverprofile=coverage.out -coverpkg ./... ./...
ok      github.com/dell/csi-powerstore/pkg/array        0.151s  coverage: 3.1% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/common       0.159s  coverage: 1.3% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/common/fs    0.158s  coverage: 0.9% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/controller   0.869s  coverage: 42.3% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/identity     0.159s  coverage: 0.2% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/interceptors 2.850s  coverage: 1.8% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/node 0.865s  coverage: 37.8% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/tracer       0.151s  coverage: 0.2% of statements in ./...
**Code Coverage**: 87.6%