### PR TITLE
bugfix krv-1492

### DIFF
--- a/helm/csi-powerstore/templates/node.yaml
+++ b/helm/csi-powerstore/templates/node.yaml
@@ -136,6 +136,12 @@ spec:
               value: /powerstore-config-params/driver-config-params.yaml
             - name: GOPOWERSTORE_DEBUG
               value: "true"
+            {{- if hasKey .Values.node "healthMonitor" }}
+            {{- if eq .Values.node.healthMonitor.enabled true}}
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "{{ .Values.controller.healthMonitor.enabled }}"
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/{{ .Values.driverName }}

--- a/helm/csi-powerstore/values.yaml
+++ b/helm/csi-powerstore/values.yaml
@@ -140,6 +140,14 @@ node:
   # Default value: None
   nodeIDPath: /etc/machine-id
 
+  healthMonitor:
+    # enabled: Enable/Disable health monitor of CSI volumes- volume usage, volume condition
+    # Allowed values:
+    #   true: enable checking of health condition of CSI volumes
+    #   false: disable checking of health condition of CSI volumes
+    # Default value: None
+    enabled: false
+
   # nodeSelector: Define node selection constraints for node pods.
   # For the pod to be eligible to run on a node, the node must have each
   # of the indicated key-value pairs as labels.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2885,6 +2885,13 @@ var _ = Describe("CSIControllerService", func() {
 						{
 							Type: &csi.ControllerServiceCapability_Rpc{
 								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+								},
+							},
+						},
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
 									Type: csi.ControllerServiceCapability_RPC_GET_VOLUME,
 								},
 							},
@@ -2961,6 +2968,13 @@ var _ = Describe("CSIControllerService", func() {
 							Type: &csi.ControllerServiceCapability_Rpc{
 								Rpc: &csi.ControllerServiceCapability_RPC{
 									Type: csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
+								},
+							},
+						},
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
 								},
 							},
 						},

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -37,6 +37,7 @@ import (
 	"github.com/dell/csi-powerstore/pkg/common/fs"
 	"github.com/dell/csi-powerstore/pkg/controller"
 	"github.com/dell/gobrick"
+	csictx "github.com/dell/gocsi/context"
 	"github.com/dell/gofsutil"
 	"github.com/dell/goiscsi"
 	"github.com/dell/gopowerstore"
@@ -72,9 +73,10 @@ type Service struct {
 	opts   Opts
 	nodeID string
 
-	useFC       bool
-	initialized bool
-	reusedHost  bool
+	useFC                  bool
+	initialized            bool
+	reusedHost             bool
+	isHealthMonitorEnabled bool
 
 	array.Locker
 }
@@ -82,6 +84,7 @@ type Service struct {
 // Init initializes node service by parsing environmental variables, connecting it as a host.
 // Will init ISCSIConnector, FcConnector and ControllerService if they are nil.
 func (s *Service) Init() error {
+	ctx := context.Background()
 	s.opts = getNodeOptions()
 
 	s.initConnectors()
@@ -133,6 +136,10 @@ func (s *Service) Init() error {
 		if err != nil {
 			log.Errorf("can't setup host on %s: %s", arr.Endpoint, err.Error())
 		}
+	}
+
+	if isHealthMonitorEnabled, ok := csictx.LookupEnv(ctx, common.EnvIsHealthMonitorEnabled); ok {
+		s.isHealthMonitorEnabled, _ = strconv.ParseBool(isHealthMonitorEnabled)
 	}
 
 	return nil
@@ -554,11 +561,28 @@ func (s *Service) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolume
 				}
 				return resp, nil
 			}
+
 			if host.Name != s.nodeID {
 				resp := &csi.NodeGetVolumeStatsResponse{
 					VolumeCondition: &csi.VolumeCondition{
 						Abnormal: true,
 						Message:  fmt.Sprintf("host %s is not attached to volume %s", s.nodeID, id),
+					},
+				}
+				return resp, nil
+			}
+
+			iscsiConnection := false
+			for _, initiator := range host.Initiators {
+				if len(initiator.ActiveSessions) > 0 {
+					iscsiConnection = false
+				}
+			}
+			if !iscsiConnection {
+				resp := &csi.NodeGetVolumeStatsResponse{
+					VolumeCondition: &csi.VolumeCondition{
+						Abnormal: true,
+						Message:  fmt.Sprintf("host %s has no active initiator connection", s.nodeID),
 					},
 				}
 				return resp, nil
@@ -867,43 +891,35 @@ func (s *Service) nodeExpandRawBlockVolume(ctx context.Context, volumeWWN string
 
 // NodeGetCapabilities returns supported features by the node service
 func (s *Service) NodeGetCapabilities(context context.Context, request *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	return &csi.NodeGetCapabilitiesResponse{
-		Capabilities: []*csi.NodeServiceCapability{
-			{Type: &csi.NodeServiceCapability_Rpc{
+	newCap := func(cap csi.NodeServiceCapability_RPC_Type) *csi.NodeServiceCapability {
+		return &csi.NodeServiceCapability{
+			Type: &csi.NodeServiceCapability_Rpc{
 				Rpc: &csi.NodeServiceCapability_RPC{
-					Type: csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+					Type: cap,
 				},
 			},
-			},
-			{
-				Type: &csi.NodeServiceCapability_Rpc{
-					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
-					},
-				},
-			},
-			{
-				Type: &csi.NodeServiceCapability_Rpc{
-					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
-					},
-				},
-			},
-			{
-				Type: &csi.NodeServiceCapability_Rpc{
-					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
-					},
-				},
-			},
-			{
-				Type: &csi.NodeServiceCapability_Rpc{
-					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
-					},
-				},
-			},
-		},
+		}
+	}
+	var capabilities []*csi.NodeServiceCapability
+	for _, capability := range []csi.NodeServiceCapability_RPC_Type{
+		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+		csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+	} {
+		capabilities = append(capabilities, newCap(capability))
+	}
+
+	if s.isHealthMonitorEnabled {
+		for _, capability := range []csi.NodeServiceCapability_RPC_Type{
+			csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+			csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
+		} {
+			capabilities = append(capabilities, newCap(capability))
+		}
+	}
+
+	return &csi.NodeGetCapabilitiesResponse{
+		Capabilities: capabilities,
 	}, nil
 }
 


### PR DESCRIPTION
# Description
bugfix krv-1492, node get volume stats made optional

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/73 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Test in k8s cluster

Test Results:
[csi-powerstore]# make test
go clean -cache; cd ./pkg; go test -race -cover -coverprofile=coverage.out -coverpkg ./... ./...
ok      github.com/dell/csi-powerstore/pkg/array        0.194s  coverage: 3.1% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/common       0.164s  coverage: 1.3% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/common/fs    0.200s  coverage: 0.9% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/controller   0.850s  coverage: 42.0% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/identity     0.171s  coverage: 0.2% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/interceptors 2.891s  coverage: 1.8% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/node 0.871s  coverage: 38.1% of statements in ./...
ok      github.com/dell/csi-powerstore/pkg/tracer       0.151s  coverage: 0.2% of statements in ./...