### PR TITLE
Remove deprecated information

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,37 +40,6 @@ If you want to use NFS be sure to enable it in `myvalues.yaml` or in your storag
 ## Driver Installation
 Please consult the [Installation Guide](https://dell.github.io/csm-docs/docs/csidriver/installation)
 
-### Prerequisites
-- Upstream Kubernetes versions 1.19, 1.20 or 1.21 or OpenShift versions 4.6 (EUS), 4.7
-- You can access your cluster with `kubectl` and `helm`
-- Optionally ensure that you have both [Volume Snapshot CRDs](https://github.com/kubernetes-csi/external-snapshotter/tree/v4.0.0/client/config/crd)
- and [common snapshot controller](https://github.com/kubernetes-csi/external-snapshotter/tree/v4.0.0/deploy/kubernetes/snapshot-controller) installed in your Kubernetes cluster and Snaphot feature is enabled in your copy of `values.yaml` if you want to use the feature.
-
-### Procedure
-1. Run `git clone https://github.com/dell/csi-powerstore.git` to clone the git repository
-2. Ensure that you've created namespace where you want to install the driver. You can run `kubectl create namespace csi-powerstore` to create a new one. 
-3. Edit `helm/secret.yaml`, correct namespace field to point to your desired namespace
-4. Edit `helm/config.yaml` file and configure connection information for your PowerStore arrays changing following parameters:
-    - *endpoint*: defines the full URL path to the PowerStore API.
-    - *globalID*: specifies what storage cluster the driver should use
-    - *username*, *password*: defines credentials for connecting to array.
-    - *skipCertificateValidation*: defines if we should use insecure connection or not.
-    - *isDefault*: defines if we should treat the current array as a default.
-    - *blockProtocol*: defines what SCSI transport protocol we should use (FC, ISCSI, None, or auto).
-    - *nasName*: defines what NAS should be used for NFS volumes.
- 
-    Add more blocks similar to above for each PowerStore array if necessary. 
-5. Create storage classes using ones from `helm/samples/storageclass` folder as an example and apply them to the Kubernetes cluster by running `kubectl create -f <path_to_storageclass_file>`
-    > If you don't specify `arrayID` parameter in the storage class then the array that was specified as the default would be used for provisioning volumes. `arrayID` corresponds to `globalID` of storage cluster.
-6. Create the secret by running ```sed "s/CONFIG_YAML/`cat helm/config.yaml | base64 -w0`/g" helm/secret.yaml | kubectl apply -f -```
-7. Copy the default values.yaml file `cd dell-csi-helm-installer && cp ../helm/csi-powerstore/values.yaml ./my-powerstore-settings.yaml`
-8. Edit the newly created file and provide values for the following parameters:
-    - *volumeNamePrefix*: defines the string added to each volume that the CSI driver creates
-    - *nodeNamePrefix*: defines the string added to each node that the CSI driver registers
-    - *nodeIDPath*: defines a path to file with a unique identifier identifying the node in the Kubernetes cluster
-    - *externalAccess*: defines additional entries for hostAccess of NFS volumes, single IP address and subnet are valid entries.
-9. Install the driver using `csi-install.sh` bash script by running `./csi-install.sh --namespace csi-powerstore --values ./my-powerstore-settings.yaml` 
-
 ## Using Driver
 Please refer to the section `Testing Drivers` in the [Documentation](https://dell.github.io/csm-docs/docs/csidriver/installation/test/) for more info.
 


### PR DESCRIPTION
# Description
The README.md referred to the deprecated version of kubernetes and lead to confusion.
The proposed change makes the README.md consistent with what is done in other drivers.


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Read from Github