### PR TITLE
Bugfix- NFS external access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/dell/gofsutil v1.7.1-0.20220302093137-8dccd83747e2
 	github.com/dell/goiscsi v1.2.1-0.20220222054507-9cc2d02a05dd
 	github.com/dell/gonvme v0.0.0-20220224072409-dcb82cef802a
-	github.com/dell/gopowerstore v1.6.1-0.20220222053212-27c8b34ab4ac
+	github.com/dell/gopowerstore v1.6.1-0.20220304101916-7cdf3f4af3b5
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/dell/csi-powerstore
 
 go 1.17
 
-replace github.com/dell/gopowerstore v1.6.1-0.20220217053906-266b40ccdb6e => ../gopowerstore
-
 require (
 	github.com/akutz/gosync v0.1.0
 	github.com/container-storage-interface/spec v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/dell/csi-powerstore
 
 go 1.17
 
+replace github.com/dell/gopowerstore v1.6.1-0.20220217053906-266b40ccdb6e => ../gopowerstore
+
 require (
 	github.com/akutz/gosync v0.1.0
 	github.com/container-storage-interface/spec v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/dell/goiscsi v1.2.1-0.20220222054507-9cc2d02a05dd h1:PgxNq8K1lXQSvUXL
 github.com/dell/goiscsi v1.2.1-0.20220222054507-9cc2d02a05dd/go.mod h1:4H4vlwEh9ujB+4kgAMNzRT8w17Gsen/BusH49k99bPE=
 github.com/dell/gonvme v0.0.0-20220224072409-dcb82cef802a h1:VbnFMQoJ0XYCwQbCktQlkqyrpBKaQu/vyXs8Ss5KSGQ=
 github.com/dell/gonvme v0.0.0-20220224072409-dcb82cef802a/go.mod h1:JXLmgxE/2dsiXqW5E+kH5Zo11lOjCuHyiHu92xqR9O0=
-github.com/dell/gopowerstore v1.6.1-0.20220222053212-27c8b34ab4ac h1:FCKYZmkZp6n4yi9Ydx37HsBjIX84GwVkig7XdDrrDh0=
-github.com/dell/gopowerstore v1.6.1-0.20220222053212-27c8b34ab4ac/go.mod h1:eE2UvjjuojzjzUqDdEC+ei5+oxJhnnS7LQfSCOo9XA8=
+github.com/dell/gopowerstore v1.6.1-0.20220304101916-7cdf3f4af3b5 h1:UfHF2CzB1hE4FpPzQaZe7skvKxItmeuIv4HDzP4kP+c=
+github.com/dell/gopowerstore v1.6.1-0.20220304101916-7cdf3f4af3b5/go.mod h1:XMGC3vgdmqk3F0VyZe4HdzfvyOfuQzLikFEKN9nKixg=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/dell/gobrick v1.2.1-0.20220224111903-717383a5e97e h1:i0nVa6y/bQ+Z7nWw
 github.com/dell/gobrick v1.2.1-0.20220224111903-717383a5e97e/go.mod h1:2dGTtzQNQx/EhDaO9vFuApWy55IXiQue0I1duXdvm14=
 github.com/dell/gocsi v1.5.1-0.20220218201557-b18545e234c3 h1:kxuw6ZTvkhTGPuz8ANx4IIFIzdzO/XiYG18uJGgr05s=
 github.com/dell/gocsi v1.5.1-0.20220218201557-b18545e234c3/go.mod h1:GoNFNluCYj7i9AcPQy4CLFF1FQoLsD5rlnDttVesnzk=
-github.com/dell/gofsutil v1.7.1-0.20220222054218-54aba58afa13 h1:6chFUTevM2q+CwN/X8jO9nE7A/IvpgDjkHTlh66qYz4=
-github.com/dell/gofsutil v1.7.1-0.20220222054218-54aba58afa13/go.mod h1:oWLiV7FmBurEie3An11SNqQ1ReyOiqjSZaXDRhm7tMc=
 github.com/dell/gofsutil v1.7.1-0.20220302093137-8dccd83747e2 h1:avM1qrtUQnSbyk7kuwXGK80xavX/hL2IlAzJafh4Wbg=
 github.com/dell/gofsutil v1.7.1-0.20220302093137-8dccd83747e2/go.mod h1:oWLiV7FmBurEie3An11SNqQ1ReyOiqjSZaXDRhm7tMc=
 github.com/dell/goiscsi v1.1.0/go.mod h1:MfuMjbKWsh/MOb0VDW20C+LFYRIOfWKGiAxWkeM5TKo=

--- a/pkg/controller/publisher.go
+++ b/pkg/controller/publisher.go
@@ -246,9 +246,6 @@ func (n *NfsPublisher) Publish(ctx context.Context, req *csi.ControllerPublishVo
 		AddRWRootHosts: ipWithNat,
 	}, export.ID)
 	if err != nil {
-		eType, okVal := err.(gopowerstore.APIError)
-		log.Info(eType)
-		log.Info(okVal)
 		if apiError, ok := err.(gopowerstore.APIError); !(ok && (apiError.NotFound() || apiError.HostAlreadyPresentInNFSExport())) {
 			return nil, status.Errorf(codes.Internal, "failure when adding new host to nfs export: %s", err.Error())
 		}

--- a/pkg/controller/publisher.go
+++ b/pkg/controller/publisher.go
@@ -246,7 +246,8 @@ func (n *NfsPublisher) Publish(ctx context.Context, req *csi.ControllerPublishVo
 		AddRWRootHosts: ipWithNat,
 	}, export.ID)
 	if err != nil {
-		if apiError, ok := err.(gopowerstore.APIError); !(ok && apiError.NotFound()) {
+		// added 400 bad request error with OR condition check here for customer issue fix
+		if apiError, ok := err.(gopowerstore.APIError); !(ok && (apiError.NotFound() || apiError.HostIsNotAttachedToVolume())) {
 			return nil, status.Errorf(codes.Internal, "failure when adding new host to nfs export: %s", err.Error())
 		}
 	}

--- a/pkg/controller/publisher.go
+++ b/pkg/controller/publisher.go
@@ -247,7 +247,11 @@ func (n *NfsPublisher) Publish(ctx context.Context, req *csi.ControllerPublishVo
 	}, export.ID)
 	if err != nil {
 		// added 400 bad request error with OR condition check here for customer issue fix
-		if apiError, ok := err.(gopowerstore.APIError); !(ok && (apiError.NotFound() || apiError.HostIsNotAttachedToVolume())) {
+		log.Info("---ADDED 400 CHECK---")
+		eType, okVal := err.(gopowerstore.APIError)
+		log.Info(eType)
+		log.Info(okVal)
+		if apiError, ok := err.(gopowerstore.APIError); !(ok && (apiError.NotFound() || apiError.HostAlreadyPresentInNFSExport())) {
 			return nil, status.Errorf(codes.Internal, "failure when adding new host to nfs export: %s", err.Error())
 		}
 	}

--- a/pkg/controller/publisher.go
+++ b/pkg/controller/publisher.go
@@ -246,8 +246,6 @@ func (n *NfsPublisher) Publish(ctx context.Context, req *csi.ControllerPublishVo
 		AddRWRootHosts: ipWithNat,
 	}, export.ID)
 	if err != nil {
-		// added 400 bad request error with OR condition check here for customer issue fix
-		log.Info("---ADDED 400 CHECK---")
 		eType, okVal := err.(gopowerstore.APIError)
 		log.Info(eType)
 		log.Info(okVal)


### PR DESCRIPTION
# Description
When the external access parameter is set in values.yaml idempotency check was failing -  This will address that issue
This should be merged only after this:  https://github.com/dell/gopowerstore/pull/17 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested in kubernetes cluster
![Screenshot (1)](https://user-images.githubusercontent.com/16013784/156730252-d73aecdd-3041-4a11-82f1-2aa6b70cd529.png)
