### PR TITLE
bugfix/error-driver-pods

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -118,25 +118,25 @@ func (s *Service) Init() error {
 		switch arr.BlockProtocol {
 		case common.NVMETCPTransport:
 			if len(nvmeInitiators) == 0 {
-				return fmt.Errorf("NVMeTCP transport was requested but NVMe initiator is not available")
+				log.Errorf("NVMeTCP transport was requested but NVMe initiator is not available")
 			}
 			s.useNVME = true
 			s.useFC = false
 		case common.NVMEFCTransport:
 			if len(nvmeInitiators) == 0 {
-				return fmt.Errorf("NVMeFC transport was requested but NVMe initiator is not available")
+				log.Errorf("NVMeFC transport was requested but NVMe initiator is not available")
 			}
 			s.useNVME = true
 			s.useFC = true
 		case common.ISCSITransport:
 			if len(iscsiInitiators) == 0 {
-				return fmt.Errorf("iSCSI transport was requested but iSCSI initiator is not available")
+				log.Errorf("iSCSI transport was requested but iSCSI initiator is not available")
 			}
 			s.useNVME = false
 			s.useFC = false
 		case common.FcTransport:
 			if len(fcInitiators) == 0 {
-				return fmt.Errorf("FC transport was requested but FC initiator is not available")
+				log.Errorf("FC transport was requested but FC initiator is not available")
 			}
 			s.useNVME = false
 			s.useFC = true


### PR DESCRIPTION
# Description
PR for replacing the return statements with log statements incase of wrong initiators

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] The driver pods of the iscsi node go to running state even if we pass the blockProtocol as NVMeFC and there are no iscsi initiators on the node.
