### PR TITLE
Environment variable check before creating the host on array

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1407,9 +1407,7 @@ func (s *Service) createHost(ctx context.Context, initiators []string, client go
 	osType := gopowerstore.OSTypeEnumLinux
 	reqInitiators := s.buildInitiatorsArray(initiators)
 	description := fmt.Sprintf("k8s node: %s", s.opts.KubeNodeName)
-	metadata := map[string]string{
-		"k8s_node_name": s.opts.KubeNodeName,
-	}
+
 	var createParams gopowerstore.HostCreate
 	defaultHeaders := client.GetCustomHTTPHeaders()
 	if defaultHeaders == nil {
@@ -1420,8 +1418,18 @@ func (s *Service) createHost(ctx context.Context, initiators []string, client go
 	if k8sMetadataSupported {
 		customHeaders.Add("DELL-VISIBILITY", "internal")
 		client.SetCustomHTTPHeaders(customHeaders)
-		createParams = gopowerstore.HostCreate{Name: &s.nodeID, OsType: &osType, Initiators: &reqInitiators,
-			Description: &description, Metadata: &metadata}
+
+		if s.opts.KubeNodeName == "" {
+			log.Warnf("KubeNodeName value is not set")
+			createParams = gopowerstore.HostCreate{Name: &s.nodeID, OsType: &osType, Initiators: &reqInitiators,
+				Description: &description}
+		} else {
+			metadata := map[string]string{
+				"k8s_node_name": s.opts.KubeNodeName,
+			}
+			createParams = gopowerstore.HostCreate{Name: &s.nodeID, OsType: &osType, Initiators: &reqInitiators,
+				Description: &description, Metadata: &metadata}
+		}
 	} else {
 		createParams = gopowerstore.HostCreate{Name: &s.nodeID, OsType: &osType, Initiators: &reqInitiators,
 			Description: &description}


### PR DESCRIPTION
…rray

# Description
Environment variable (X_CSI_POWERSTORE_KUBE_NODE_NAME) check before sending the create host request to the array.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Have renamed the environment variable with some different name to make sure that host get added to the array even without metadata.
- [x] Set a proper value of this environment variable in the sample file and installed the driver using helm operator's sample script and verified that the host got added to the array.
