### PR TITLE
Fix for Scaling suite failing for NFS topology

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -325,7 +325,7 @@ func ParseCIDR(externalAccessCIDR string) (string, error) {
 	return externalAccess, nil
 }
 
-// Checks if requiredTopology is present in the topology array and is true
+// HasRequiredTopology Checks if requiredTopology is present in the topology array and is true
 func HasRequiredTopology(topologies []*csi.Topology, arrIP string, requiredTopology string) bool {
 	if len(topologies) == 0 || len(arrIP) == 0 || len(requiredTopology) == 0 {
 		return false
@@ -340,7 +340,7 @@ func HasRequiredTopology(topologies []*csi.Topology, arrIP string, requiredTopol
 	return false
 }
 
-// Returns a topology array with only nfs
+// GetNfsTopology Returns a topology array with only nfs
 func GetNfsTopology(arrIP string) []*csi.Topology {
 	nfsTopology := new(csi.Topology)
 	nfsTopology.Segments = map[string]string{Name + "/" + arrIP + "-nfs": "true"}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/apparentlymart/go-cidr/cidr"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/dell/csi-powerstore/core"
 	"github.com/dell/csi-powerstore/pkg/common/fs"
 	"github.com/dell/gobrick"
@@ -322,4 +323,26 @@ func ParseCIDR(externalAccessCIDR string) (string, error) {
 	externalAccess := start.String() + "/" + s[1]
 
 	return externalAccess, nil
+}
+
+// Checks if requiredTopology is present in the topology array and is true
+func HasRequiredTopology(topologies []*csi.Topology, arrIP string, requiredTopology string) bool {
+	if len(topologies) == 0 || len(arrIP) == 0 || len(requiredTopology) == 0 {
+		return false
+	}
+
+	topologyKey := Name + "/" + arrIP + "-" + strings.ToLower(requiredTopology)
+	for _, topology := range topologies {
+		if value, ok := topology.Segments[topologyKey]; ok && strings.EqualFold(value, "true") {
+			return true
+		}
+	}
+	return false
+}
+
+// Returns a topology array with only nfs
+func GetNfsTopology(arrIP string) []*csi.Topology {
+	nfsTopology := new(csi.Topology)
+	nfsTopology.Segments = map[string]string{Name + "/" + arrIP + "-nfs": "true"}
+	return []*csi.Topology{nfsTopology}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -234,7 +234,7 @@ func (s *Service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		volResp.VolumeId = volResp.VolumeId + "/" + arr.GetGlobalID() + "/" + protocol
 		if useNFS {
 			topology = common.GetNfsTopology(arr.GetIP())
-			log.Info("Modified topology to nfs for %s", req.GetName())
+			log.Infof("Modified topology to nfs for %s", req.GetName())
 		}
 		volResp.AccessibleTopology = topology
 		return &csi.CreateVolumeResponse{
@@ -353,7 +353,7 @@ func (s *Service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		volumeResponse.VolumeContext[common.KeyNfsACL] = nfsAcls
 		volumeResponse.VolumeContext[common.KeyNasName] = arr.GetNasName()
 		topology = common.GetNfsTopology(arr.GetIP())
-		log.Info("Modified topology to nfs for %s", req.GetName())
+		log.Infof("Modified topology to nfs for %s", req.GetName())
 	}
 
 	volumeResponse.VolumeId = volumeResponse.VolumeId + "/" + arr.GetGlobalID() + "/" + protocol

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -149,6 +149,13 @@ func (s *Service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		}
 	}
 
+	// Prevent user from creating an NFS volume with incorrect topology(e.g. iscsi, nvme). At least one entry for nfs should be present in the topology, otherwise return an error
+	if useNFS && req.AccessibilityRequirements != nil {
+		if ok := common.HasRequiredTopology(req.AccessibilityRequirements.Preferred, arr.GetIP(), "nfs"); !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid topology requested for NFS Volume. Please validate your storage class has nfs topology.")
+		}
+	}
+
 	var creator VolumeCreator
 	var protocol string
 
@@ -225,6 +232,10 @@ func (s *Service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 			return nil, err
 		}
 		volResp.VolumeId = volResp.VolumeId + "/" + arr.GetGlobalID() + "/" + protocol
+		if useNFS {
+			topology = common.GetNfsTopology(arr.GetIP())
+			log.Info("Modified topology to nfs for %s", req.GetName())
+		}
 		volResp.AccessibleTopology = topology
 		return &csi.CreateVolumeResponse{
 			Volume: volResp,
@@ -341,6 +352,8 @@ func (s *Service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 	if useNFS {
 		volumeResponse.VolumeContext[common.KeyNfsACL] = nfsAcls
 		volumeResponse.VolumeContext[common.KeyNasName] = arr.GetNasName()
+		topology = common.GetNfsTopology(arr.GetIP())
+		log.Info("Modified topology to nfs for %s", req.GetName())
 	}
 
 	volumeResponse.VolumeId = volumeResponse.VolumeId + "/" + arr.GetGlobalID() + "/" + protocol

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -439,6 +439,7 @@ var _ = Describe("CSIControllerService", func() {
 							controller.KeyCSIPVCName:      req.Name,
 							controller.KeyCSIPVCNamespace: validNamespaceName,
 						},
+						AccessibleTopology: []*csi.Topology{{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}},
 					},
 				}))
 			})
@@ -474,6 +475,7 @@ var _ = Describe("CSIControllerService", func() {
 							controller.KeyCSIPVCName:      req.Name,
 							controller.KeyCSIPVCNamespace: validNamespaceName,
 						},
+						AccessibleTopology: []*csi.Topology{{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}},
 					},
 				}))
 			})
@@ -508,6 +510,7 @@ var _ = Describe("CSIControllerService", func() {
 							controller.KeyCSIPVCName:      req.Name,
 							controller.KeyCSIPVCNamespace: validNamespaceName,
 						},
+						AccessibleTopology: []*csi.Topology{{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}},
 					},
 				}))
 			})
@@ -540,6 +543,7 @@ var _ = Describe("CSIControllerService", func() {
 							controller.KeyCSIPVCName:      req.Name,
 							controller.KeyCSIPVCNamespace: validNamespaceName,
 						},
+						AccessibleTopology: []*csi.Topology{{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}},
 					},
 				}))
 			})
@@ -577,6 +581,7 @@ var _ = Describe("CSIControllerService", func() {
 							controller.KeyCSIPVCName:      req.Name,
 							controller.KeyCSIPVCNamespace: validNamespaceName,
 						},
+						AccessibleTopology: []*csi.Topology{{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}},
 					},
 				}))
 			})
@@ -590,7 +595,10 @@ var _ = Describe("CSIControllerService", func() {
 				req.Parameters[controller.KeyCSIPVCName] = req.Name
 				req.Parameters[controller.KeyCSIPVCNamespace] = validNamespaceName
 
-				req.AccessibilityRequirements = nil
+				iscsiTopology := &csi.Topology{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-iscsi": "true"}}
+				preferred := []*csi.Topology{iscsiTopology}
+				accessibilityRequirements := &csi.TopologyRequirement{Preferred: preferred}
+				req.AccessibilityRequirements = accessibilityRequirements
 
 				res, err := ctrlSvc.CreateVolume(context.Background(), req)
 
@@ -715,6 +723,7 @@ var _ = Describe("CSIControllerService", func() {
 							controller.KeyCSIPVCName:      req.Name,
 							controller.KeyCSIPVCNamespace: validNamespaceName,
 						},
+						AccessibleTopology: []*csi.Topology{{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}},
 					},
 				}))
 			})
@@ -851,7 +860,8 @@ var _ = Describe("CSIControllerService", func() {
 						VolumeContext: map[string]string{
 							common.KeyArrayID: secondValidID,
 						},
-						ContentSource: contentSource,
+						ContentSource:      contentSource,
+						AccessibleTopology: []*csi.Topology{{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}},
 					},
 				}))
 			})
@@ -935,7 +945,8 @@ var _ = Describe("CSIControllerService", func() {
 						VolumeContext: map[string]string{
 							common.KeyArrayID: secondValidID,
 						},
-						ContentSource: contentSource,
+						ContentSource:      contentSource,
+						AccessibleTopology: []*csi.Topology{{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}},
 					},
 				}))
 			})

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -105,6 +105,7 @@ func setVariables() {
 		Insecure:      true,
 		IsDefault:     true,
 		Client:        clientMock,
+		IP:            "192.168.0.1",
 	}
 	second := &array.PowerStoreArray{
 		Endpoint:      "https://192.168.0.2/api/rest",
@@ -115,6 +116,7 @@ func setVariables() {
 		BlockProtocol: common.NoneTransport,
 		Insecure:      true,
 		Client:        clientMock,
+		IP:            "192.168.0.2",
 	}
 
 	arrays[firstValidID] = first
@@ -575,6 +577,60 @@ var _ = Describe("CSIControllerService", func() {
 							controller.KeyCSIPVCName:      req.Name,
 							controller.KeyCSIPVCNamespace: validNamespaceName,
 						},
+					},
+				}))
+			})
+		})
+
+		When("creating nfs volume without nfs topology in AccessibilityRequirements", func() {
+			It("should fail", func() {
+				req := getTypicalCreateVolumeNFSRequest("my-vol", validVolSize)
+				req.Parameters[common.KeyArrayID] = secondValidID
+
+				req.Parameters[controller.KeyCSIPVCName] = req.Name
+				req.Parameters[controller.KeyCSIPVCNamespace] = validNamespaceName
+
+				req.AccessibilityRequirements = nil
+
+				res, err := ctrlSvc.CreateVolume(context.Background(), req)
+
+				Expect(res).To(BeNil())
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("invalid topology requested for NFS Volume. Please validate your storage class has nfs topology."))
+			})
+		})
+
+		When("creating nfs volume with more than one topology in AccessibilityRequirements", func() {
+			It("should return only nfs topology", func() {
+				clientMock.On("GetNASByName", mock.Anything, validNasName).Return(gopowerstore.NAS{ID: validNasID}, nil)
+				clientMock.On("CreateFS", mock.Anything, mock.Anything).Return(gopowerstore.CreateResponse{ID: validBaseVolID}, nil)
+
+				req := getTypicalCreateVolumeNFSRequest("my-vol", validVolSize)
+				req.Parameters[common.KeyArrayID] = secondValidID
+
+				req.Parameters[controller.KeyCSIPVCName] = req.Name
+				req.Parameters[controller.KeyCSIPVCNamespace] = validNamespaceName
+
+				iscsiTopology := &csi.Topology{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-iscis": "true"}}
+				req.AccessibilityRequirements.Preferred = append(req.AccessibilityRequirements.Preferred, iscsiTopology)
+
+				res, err := ctrlSvc.CreateVolume(context.Background(), req)
+				Expect(err).To(BeNil())
+				Expect(res).To(Equal(&csi.CreateVolumeResponse{
+					Volume: &csi.Volume{
+						CapacityBytes: validVolSize,
+						VolumeId:      filepath.Join(validBaseVolID, secondValidID, "nfs"),
+						VolumeContext: map[string]string{
+							common.KeyArrayVolumeName:     "my-vol",
+							common.KeyProtocol:            "nfs",
+							common.KeyArrayID:             secondValidID,
+							common.KeyNfsACL:              "A::OWNER@:RWX",
+							common.KeyNasName:             validNasName,
+							common.KeyVolumeDescription:   req.Name + "-" + validNamespaceName,
+							controller.KeyCSIPVCName:      req.Name,
+							controller.KeyCSIPVCNamespace: validNamespaceName,
+						},
+						AccessibleTopology: []*csi.Topology{{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}},
 					},
 				}))
 			})
@@ -3848,6 +3904,11 @@ func getTypicalCreateVolumeNFSRequest(name string, size int64) *csi.CreateVolume
 	capabilities := make([]*csi.VolumeCapability, 0)
 	capabilities = append(capabilities, getVolumeCapabilityNFS())
 	req.VolumeCapabilities = capabilities
+
+	nfsTopology := &csi.Topology{Segments: map[string]string{common.Name + "/" + ctrlSvc.Arrays()[secondValidID].GetIP() + "-nfs": "true"}}
+	preferred := []*csi.Topology{nfsTopology}
+	accessibilityRequirements := &csi.TopologyRequirement{Preferred: preferred}
+	req.AccessibilityRequirements = accessibilityRequirements
 	return req
 }
 


### PR DESCRIPTION
# Description
Scaling suite in certify suite cert-csi is failing with new NFS storage class sample given in csi-powerstore repo.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Validated the changes in mixed protocol cluster by creating a nfs pvc & pod using a nfs storage class without using topology.
- [x] Validated that an error is thrown if nfs storage class has topology but its not nfs. 
