### PR TITLE
Fix for Scaling suite failing for NFS topology

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/apparentlymart/go-cidr/cidr"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/dell/csi-powerstore/core"
 	"github.com/dell/csi-powerstore/pkg/common/fs"
 	"github.com/dell/gobrick"
@@ -322,4 +323,26 @@ func ParseCIDR(externalAccessCIDR string) (string, error) {
 	externalAccess := start.String() + "/" + s[1]
 
 	return externalAccess, nil
+}
+
+// HasRequiredTopology Checks if requiredTopology is present in the topology array and is true
+func HasRequiredTopology(topologies []*csi.Topology, arrIP string, requiredTopology string) bool {
+	if len(topologies) == 0 || len(arrIP) == 0 || len(requiredTopology) == 0 {
+		return false
+	}
+
+	topologyKey := Name + "/" + arrIP + "-" + strings.ToLower(requiredTopology)
+	for _, topology := range topologies {
+		if value, ok := topology.Segments[topologyKey]; ok && strings.EqualFold(value, "true") {
+			return true
+		}
+	}
+	return false
+}
+
+// GetNfsTopology Returns a topology array with only nfs
+func GetNfsTopology(arrIP string) []*csi.Topology {
+	nfsTopology := new(csi.Topology)
+	nfsTopology.Segments = map[string]string{Name + "/" + arrIP + "-nfs": "true"}
+	return []*csi.Topology{nfsTopology}
 }


### PR DESCRIPTION
# Description
Scaling suite in certify suite cert-csi is failing with new NFS storage class sample given in csi-powerstore repo.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Validated the changes in mixed protocol cluster by creating a nfs pvc & pod using a nfs storage class without using topology.
- [x] Validated that an error is thrown if nfs storage class has topology but its not nfs.
