### PR TITLE
Feature/k8 1.25 support

### DIFF
--- a/dell-csi-helm-installer/verify-csi-powerstore.sh
+++ b/dell-csi-helm-installer/verify-csi-powerstore.sh
@@ -10,7 +10,7 @@
 
 # verify-csi-powerstore method
 function verify-csi-powerstore() {
-  verify_k8s_versions "1.21" "1.24"
+  verify_k8s_versions "1.21" "1.25"
   verify_openshift_versions "4.9" "4.10"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-config"

--- a/helm/csi-powerstore/Chart.yaml
+++ b/helm/csi-powerstore/Chart.yaml
@@ -2,10 +2,9 @@ name: csi-powerstore
 apiVersion: v2
 version: 2.4.0
 appVersion: "2.4.0"
-kubeVersion: ">= 1.21.0 < 1.25.0"
+kubeVersion: ">= 1.21.0 < 1.26.0"
 #If you are using a complex K8s version like "v1.22.3-mirantis-1", use this kubeVersion check instead
 #WARNING: this version of the check will allow the use of alpha and beta versions, which is NOT SUPPORTED
-#kubeVersion: ">= 1.21.0-0 < 1.25.0-0"
 description: |
   PowerStore CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as

--- a/helm/csi-powerstore/templates/_helpers.tpl
+++ b/helm/csi-powerstore/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Return the appropriate sidecar images based on k8s version
 */}}
 {{- define "csi-powerstore.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-attacher:v3.5.0" -}}
     {{- end -}}
   {{- end -}}
@@ -11,7 +11,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powerstore.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1" -}}
     {{- end -}}
   {{- end -}}
@@ -19,7 +19,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powerstore.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1" -}}
     {{- end -}}
   {{- end -}}
@@ -27,7 +27,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powerstore.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.5.0" -}}
     {{- end -}}
   {{- end -}}
@@ -35,7 +35,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powerstore.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1" -}}
     {{- end -}}
   {{- end -}}
@@ -43,7 +43,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powerstore.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
       {{- print "gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.6.0" -}}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
# Description
Kubernete 1.25v support for CSI-PowerStore

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/478|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the driver on k8 1.25 setup and have created some PVCs and Pods. Creation and deletion of PV works fine.
- [x] Run Automation suite on k8 1.25 setup against driver and all suites runs fine.
