### PR TITLE
Fix for "failed to delete mount path" with "device or resource busy"

### DIFF
--- a/mocks/FsInterface.go
+++ b/mocks/FsInterface.go
@@ -168,6 +168,20 @@ func (_m *FsInterface) IsNotExist(err error) bool {
 	return r0
 }
 
+// IsDeviceOrResourceBusy provides a mock function with given fields: err
+func (_m *FsInterface) IsDeviceOrResourceBusy(err error) bool {
+	ret := _m.Called(err)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(error) bool); ok {
+		r0 = rf(err)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // MkFileIdempotent provides a mock function with given fields: path
 func (_m *FsInterface) MkFileIdempotent(path string) (bool, error) {
 	ret := _m.Called(path)

--- a/pkg/common/fs/fs.go
+++ b/pkg/common/fs/fs.go
@@ -21,6 +21,7 @@ package fs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -28,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/dell/gofsutil"
@@ -53,6 +55,7 @@ type Interface interface {
 	ReadFile(name string) ([]byte, error)
 	WriteFile(filename string, data []byte, perm os.FileMode) error
 	IsNotExist(err error) bool
+	IsDeviceOrResourceBusy(err error) bool
 	Mkdir(name string, perm os.FileMode) error
 	MkdirAll(name string, perm os.FileMode) error
 	Chmod(name string, perm os.FileMode) error
@@ -146,6 +149,11 @@ func (fs *Fs) Stat(name string) (FileInfo, error) {
 // IsNotExist is a wrapper of os.IsNotExist
 func (fs *Fs) IsNotExist(err error) bool {
 	return os.IsNotExist(err)
+}
+
+// IsDeviceOrResourceBusy checks for device or resource busy error
+func (fs *Fs) IsDeviceOrResourceBusy(err error) bool {
+	return errors.Unwrap(err) == syscall.EBUSY
 }
 
 // Mkdir is a wrapper of os.Mkdir

--- a/pkg/node/base.go
+++ b/pkg/node/base.go
@@ -214,7 +214,6 @@ func getRemnantTargetMounts(ctx context.Context, target string, fs fs.Interface)
 			targetMounts = append(targetMounts, mount)
 			log.WithFields(logFields).Infof("matching remnantTargetMount %s target %s", target, mount.Path)
 			found = true
-			break
 		}
 	}
 	return targetMounts, found, nil

--- a/pkg/node/base.go
+++ b/pkg/node/base.go
@@ -27,6 +27,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/dell/csi-powerstore/pkg/common"
@@ -197,6 +198,26 @@ func getStagingPath(ctx context.Context, sp string, volID string) string {
 	stagingPath := path.Join(sp, volID)
 	log.WithFields(logFields).Infof("staging path is: %s", stagingPath)
 	return path.Join(sp, volID)
+}
+
+func getRemnantTargetMounts(ctx context.Context, target string, fs fs.Interface) ([]gofsutil.Info, bool, error) {
+	logFields := common.GetLogFields(ctx)
+	var targetMounts []gofsutil.Info
+	var found bool
+	mounts, err := getMounts(ctx, fs)
+	if err != nil {
+		log.Error("could not reliably determine existing mount status")
+		return targetMounts, false, status.Error(codes.Internal, "could not reliably determine existing mount status")
+	}
+	for _, mount := range mounts {
+		if strings.Contains(mount.Path, target) {
+			targetMounts = append(targetMounts, mount)
+			log.WithFields(logFields).Infof("matching remnantTargetMount %s target %s", target, mount.Path)
+			found = true
+			break
+		}
+	}
+	return targetMounts, found, nil
 }
 
 func getTargetMount(ctx context.Context, target string, fs fs.Interface) (gofsutil.Info, bool, error) {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -397,14 +397,15 @@ func unstageVolume(ctx context.Context, stagingPath, id string, logFields log.Fi
 }
 
 func removeRemnantMounts(ctx context.Context, stagingPath string, fs fs.Interface, logFields log.Fields) (string, error) {
-	log.WithFields(logFields).Infof("getting active remnant mount")
+	log.WithFields(logFields).Infof("getting remnant mount")
 	mounts, found, err := getRemnantTargetMounts(ctx, stagingPath, fs)
 	if !found || err != nil {
 		return "", fmt.Errorf("could not reliably determine remnant mounts for path %s: %s", stagingPath, err.Error())
 	}
 
-	log.WithFields(logFields).Infof("%d active remnant mount exist", len(mounts))
+	log.WithFields(logFields).Infof("%d remnant mount exist", len(mounts))
 	for _, mount := range mounts {
+		delete(logFields, "StagingPath")
 		logFields["RemnantPath"] = mount.Path
 		err = fs.GetUtil().Unmount(ctx, mount.Path)
 		if err != nil {
@@ -413,6 +414,7 @@ func removeRemnantMounts(ctx context.Context, stagingPath string, fs fs.Interfac
 		log.WithFields(logFields).Infof("unmount without error")
 	}
 	delete(logFields, "RemnantPath")
+	logFields["StagingPath"] = stagingPath
 	return mounts[0].Device, nil
 }
 

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1377,10 +1377,11 @@ var _ = Describe("CSINodeService", func() {
 
 				utilMock.On("Unmount", mock.Anything, stagingPath).Return(nil)
 
-				fsMock.On("Remove", stagingPath).Return(errors.New("remove " + stagingPath + ": device or resource busy"))
+				fsMock.On("Remove", stagingPath).Return(errors.New("remove " + stagingPath + ": device or resource busy")).Once()
 				fsMock.On("IsDeviceOrResourceBusy", mock.Anything).Return(true)
-				fsMock.On("IsNotExist", mock.Anything).Return(false)
 				utilMock.On("Unmount", mock.Anything, remnantStagingPath).Return(nil)
+				fsMock.On("Remove", stagingPath).Return(nil).Once()
+				fsMock.On("IsNotExist", mock.Anything).Return(false)
 
 				fsMock.On("WriteFile", path.Join(nodeSvc.opts.TmpDir, validBaseVolumeID), []byte(validDevName), os.FileMode(0640)).Return(nil)
 


### PR DESCRIPTION
# Description
When using containerd, some additional mounts are automatically added upon restart of powerstore-node pod. These mounts are not removed automatically during unmounting done in NodeUnstageVolume call, as a result we see "failed to delete mount path" with "device or resource busy" error.
This fix removes any remnant mounts when "device or resource busy" error is seen while deleting staging path.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested the driver in cluster where the issue can be reproduced.
