### PR TITLE
Bugfix/discovering iscsi target

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1077,9 +1077,9 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 						continue
 					}
 					var nvmeTargets []gonvme.NVMeTarget
-					for _, addresses := range infoList {
+					for _, address := range infoList {
 						// doesn't matter how many portals are present, discovering from any one will list out all targets
-						nvmeIP := strings.Split(addresses.Portal, ":")
+						nvmeIP := strings.Split(address.Portal, ":")
 						log.Info("Trying to discover NVMe target from portal ", nvmeIP[0])
 						nvmeTargets, err = s.nvmeLib.DiscoverNVMeTCPTargets(nvmeIP[0], false)
 						if err != nil {
@@ -1147,10 +1147,10 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 				}
 
 				var iscsiTargets []goiscsi.ISCSITarget
-				for _, addresses := range infoList {
+				for _, address := range infoList {
 					// doesn't matter how many portals are present, discovering from any one will list out all targets
-					log.Info("Trying to discover iSCSI target from portal ", addresses.Portal)
-					iscsiTargets, err = s.iscsiLib.DiscoverTargets(addresses.Portal, false)
+					log.Info("Trying to discover iSCSI target from portal ", address.Portal)
+					iscsiTargets, err = s.iscsiLib.DiscoverTargets(address.Portal, false)
 					if err != nil {
 						log.Error("couldn't discover targets")
 						continue

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1143,18 +1143,27 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 					continue
 				}
 
-				iscsiTargets, err := s.iscsiLib.DiscoverTargets(infoList[0].Portal, false)
-				if err != nil {
-					log.Error("couldn't discover targets")
-					continue
-				} else {
-					for _, target := range iscsiTargets {
-						log.Info("Iscsi target", target)
-						err = s.iscsiLib.PerformLogin(target)
-						if err != nil {
-							log.Errorf("couldn't connect to the iscsi target")
+				foundOneTarget := false
+				for _, oneInfoListinfoList := range infoList {
+					iscsiTargets, err := s.iscsiLib.DiscoverTargets(oneInfoListinfoList.Portal, false)
+					if err != nil {
+						log.Error("couldn't discover targets")
+						continue
+					} else {
+						for _, target := range iscsiTargets {
+							// foundOneTarget = true
+							log.Info("Iscsi target", target)
+							err = s.iscsiLib.PerformLogin(target)
+							if err != nil {
+								// should we continue from here w/o adding labels?
+								log.Errorf("couldn't connect to the iscsi target")
+							}
+							foundOneTarget = true
 						}
 					}
+				}
+				if !foundOneTarget {
+					continue
 				}
 				resp.AccessibleTopology.Segments[common.Name+"/"+arr.GetIP()+"-iscsi"] = "true"
 			}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1076,25 +1076,29 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 						log.Errorf("couldn't get targets from array: %s", err.Error())
 						continue
 					}
-
-					log.Infof("Discovering NVMeTCP targets")
-					nvmetcpConnectCount := 0
-					nvmeIP := strings.Split(infoList[0].Portal, ":")
-					nvmeTargets, err := s.nvmeLib.DiscoverNVMeTCPTargets(nvmeIP[0], false)
-					if err != nil {
-						log.Error("couldn't discover NVMe targets")
-						continue
-					} else {
-						for _, target := range nvmeTargets {
-							err = s.nvmeLib.NVMeTCPConnect(target, false)
-							if err != nil {
-								log.Infof("couldn't connect to NVMeTCP targets")
-							} else {
-								nvmetcpConnectCount = nvmetcpConnectCount + 1
-							}
+					var nvmeTargets []gonvme.NVMeTarget
+					for _, addresses := range infoList {
+						// doesn't matter how many portals are present, discovering from any one will list out all targets
+						nvmeIP := strings.Split(addresses.Portal, ":")
+						log.Info("Trying to discover NVMe target from portal", nvmeIP[0])
+						nvmeTargets, err = s.nvmeLib.DiscoverNVMeTCPTargets(nvmeIP[0], false)
+						if err != nil {
+							log.Error("couldn't discover targets")
+							continue
 						}
+						break
 					}
-					if nvmetcpConnectCount != 0 {
+					loginToAtleastOneTarget := false
+					for _, target := range nvmeTargets {
+						log.Info("Logging to NVMe target", target)
+						err = s.nvmeLib.NVMeTCPConnect(target, false)
+						if err != nil {
+							log.Errorf("couldn't connect to the iscsi target")
+							continue
+						}
+						loginToAtleastOneTarget = true
+					}
+					if loginToAtleastOneTarget {
 						resp.AccessibleTopology.Segments[common.Name+"/"+arr.GetIP()+"-nvmetcp"] = "true"
 					}
 				}
@@ -1136,31 +1140,35 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 					continue
 				}
 			} else {
-
 				infoList, err := common.GetISCSITargetsInfoFromStorage(arr.GetClient(), "")
 				if err != nil {
 					log.Errorf("couldn't get targets from array: %s", err.Error())
 					continue
 				}
 
-				foundOneTarget := false
-				for _, oneInfoListinfoList := range infoList {
-					iscsiTargets, err := s.iscsiLib.DiscoverTargets(oneInfoListinfoList.Portal, false)
+				var iscsiTargets []goiscsi.ISCSITarget
+				for _, addresses := range infoList {
+					// doesn't matter how many portals are present, discovering from any one will list out all targets
+					log.Info("Trying to discover iSCSI target from portal", addresses.Portal)
+					iscsiTargets, err = s.iscsiLib.DiscoverTargets(addresses.Portal, false)
 					if err != nil {
 						log.Error("couldn't discover targets")
 						continue
 					}
-					for _, target := range iscsiTargets {
-						log.Info("Iscsi target", target)
-						err = s.iscsiLib.PerformLogin(target)
-						if err != nil {
-							log.Errorf("couldn't connect to the iscsi target")
-							continue
-						}
-						foundOneTarget = true
-					}
+					break
 				}
-				if foundOneTarget {
+				loginToAtleastOneTarget := false
+				for _, target := range iscsiTargets {
+					log.Info("Logging to Iscsi target", target)
+					err = s.iscsiLib.PerformLogin(target)
+					if err != nil {
+						log.Errorf("couldn't connect to the iscsi target")
+						continue
+					}
+					loginToAtleastOneTarget = true
+				}
+
+				if loginToAtleastOneTarget {
 					resp.AccessibleTopology.Segments[common.Name+"/"+arr.GetIP()+"-iscsi"] = "true"
 				}
 			}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1093,7 +1093,7 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 						log.Info("Logging to NVMe target ", target)
 						err = s.nvmeLib.NVMeTCPConnect(target, false)
 						if err != nil {
-							log.Errorf("couldn't connect to the iscsi target")
+							log.Errorf("couldn't connect to the nvme target")
 							continue
 						}
 						loginToAtleastOneTarget = true

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1149,23 +1149,20 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 					if err != nil {
 						log.Error("couldn't discover targets")
 						continue
-					} else {
-						for _, target := range iscsiTargets {
-							// foundOneTarget = true
-							log.Info("Iscsi target", target)
-							err = s.iscsiLib.PerformLogin(target)
-							if err != nil {
-								// should we continue from here w/o adding labels?
-								log.Errorf("couldn't connect to the iscsi target")
-							}
-							foundOneTarget = true
+					}
+					for _, target := range iscsiTargets {
+						log.Info("Iscsi target", target)
+						err = s.iscsiLib.PerformLogin(target)
+						if err != nil {
+							log.Errorf("couldn't connect to the iscsi target")
+							continue
 						}
+						foundOneTarget = true
 					}
 				}
-				if !foundOneTarget {
-					continue
+				if foundOneTarget {
+					resp.AccessibleTopology.Segments[common.Name+"/"+arr.GetIP()+"-iscsi"] = "true"
 				}
-				resp.AccessibleTopology.Segments[common.Name+"/"+arr.GetIP()+"-iscsi"] = "true"
 			}
 		}
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1080,7 +1080,7 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 					for _, addresses := range infoList {
 						// doesn't matter how many portals are present, discovering from any one will list out all targets
 						nvmeIP := strings.Split(addresses.Portal, ":")
-						log.Info("Trying to discover NVMe target from portal", nvmeIP[0])
+						log.Info("Trying to discover NVMe target from portal ", nvmeIP[0])
 						nvmeTargets, err = s.nvmeLib.DiscoverNVMeTCPTargets(nvmeIP[0], false)
 						if err != nil {
 							log.Error("couldn't discover targets")
@@ -1090,7 +1090,7 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 					}
 					loginToAtleastOneTarget := false
 					for _, target := range nvmeTargets {
-						log.Info("Logging to NVMe target", target)
+						log.Info("Logging to NVMe target ", target)
 						err = s.nvmeLib.NVMeTCPConnect(target, false)
 						if err != nil {
 							log.Errorf("couldn't connect to the iscsi target")
@@ -1149,7 +1149,7 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 				var iscsiTargets []goiscsi.ISCSITarget
 				for _, addresses := range infoList {
 					// doesn't matter how many portals are present, discovering from any one will list out all targets
-					log.Info("Trying to discover iSCSI target from portal", addresses.Portal)
+					log.Info("Trying to discover iSCSI target from portal ", addresses.Portal)
 					iscsiTargets, err = s.iscsiLib.DiscoverTargets(addresses.Portal, false)
 					if err != nil {
 						log.Error("couldn't discover targets")
@@ -1159,7 +1159,7 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 				}
 				loginToAtleastOneTarget := false
 				for _, target := range iscsiTargets {
-					log.Info("Logging to Iscsi target", target)
+					log.Info("Logging to Iscsi target ", target)
 					err = s.iscsiLib.PerformLogin(target)
 					if err != nil {
 						log.Errorf("couldn't connect to the iscsi target")

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -2891,6 +2891,10 @@ var _ = Describe("CSINodeService", func() {
 							Address: "192.168.1.1",
 							IPPort:  gopowerstore.IPPortInstance{TargetIqn: "iqn"},
 						},
+						{
+							Address: "192.168.1.2",
+							IPPort:  gopowerstore.IPPortInstance{TargetIqn: "iqn2"},
+						},
 					}, nil)
 				conn, _ := net.Dial("udp", "127.0.0.1:80")
 				fsMock.On("NetDial", mock.Anything).Return(
@@ -3310,6 +3314,39 @@ var _ = Describe("CSINodeService", func() {
 						},
 					},
 				}))
+			})
+
+			When("target can not be discovered", func() {
+				It("should not return nvme topology key", func() {
+					goiscsi.GOISCSIMock.InduceDiscoveryError = true
+					gonvme.GONVMEMock.InduceDiscoveryError = true
+					nodeSvc.useNVME = true
+					nodeSvc.useFC = false
+					clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).
+						Return([]gopowerstore.IPPoolAddress{
+							{
+								Address: "192.168.1.1",
+								IPPort:  gopowerstore.IPPortInstance{TargetIqn: "iqn"},
+							},
+						}, nil)
+					conn, _ := net.Dial("udp", "127.0.0.1:80")
+					fsMock.On("NetDial", mock.Anything).Return(
+						conn,
+						nil,
+					)
+					res, err := nodeSvc.NodeGetInfo(context.Background(), &csi.NodeGetInfoRequest{})
+					Expect(err).To(BeNil())
+					Expect(res).To(Equal(&csi.NodeGetInfoResponse{
+						NodeId: nodeSvc.nodeID,
+						AccessibleTopology: &csi.Topology{
+							Segments: map[string]string{
+								common.Name + "/" + firstValidIP + "-nfs":  "true",
+								common.Name + "/" + secondValidIP + "-nfs": "true",
+							},
+						},
+					}))
+					gonvme.GONVMEMock.InduceDiscoveryError = false
+				})
 			})
 
 			When("we cannot get NVMeTCP targets from the array", func() {


### PR DESCRIPTION
# Description
iSCSI/NMVe target discovery enhancement in case of multiple portals and multi network

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Configured 3 iscsi/nvme networks (6 targets, 2 out of them were unreachable) on PowerStore array and try to discover the targets with reachable and unreachable portals i.e. try until discovery is not completed with all portals.
- [x] Tried to login to unreachable targets and have seen that login has failed within 30 seconds and verified it from the log.
