### PR TITLE
enhancing NodeGetInfo & nodeProbe when iscsi login is failed

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1159,7 +1159,7 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 					}
 					break
 				}
-				// login is also performed as a part of ConnectVolume by using dynamically created chap credentials, InCase if it fails here
+				// login is also performed as a part of ConnectVolume by using dynamically created chap credentials, In case if it fails here
 				if len(iscsiTargets) > 0 {
 					resp.AccessibleTopology.Segments[common.Name+"/"+arr.GetIP()+"-iscsi"] = "true"
 				}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1159,6 +1159,10 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 					}
 					break
 				}
+				// login is also performed as a part of ConnectVolume by using dynamically created chap credentials, InCase if it fails here
+				if len(iscsiTargets) > 0 {
+					resp.AccessibleTopology.Segments[common.Name+"/"+arr.GetIP()+"-iscsi"] = "true"
+				}
 				loginToAtleastOneTarget := false
 				for _, target := range iscsiTargets {
 					log.Info("Logging to Iscsi target ", target)
@@ -1170,9 +1174,7 @@ func (s *Service) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) 
 					loginToAtleastOneTarget = true
 				}
 
-				if loginToAtleastOneTarget {
-					resp.AccessibleTopology.Segments[common.Name+"/"+arr.GetIP()+"-iscsi"] = "true"
-				} else {
+				if !loginToAtleastOneTarget {
 					s.useNFS = true
 				}
 			}

--- a/pkg/node/node_connectivity_checker.go
+++ b/pkg/node/node_connectivity_checker.go
@@ -220,15 +220,19 @@ func (s *Service) nodeProbe(timeOutCtx context.Context, array *array.PowerStoreA
 		// nodeId is not right or it's not NFS and still host is not preset
 		log.Infof("Error %s, while probing %s", err.Error(), array.GlobalID)
 		return err
-	} else if s.useNFS {
-		log.Infof("Host Entry found but failed to login to nvme/iscsi target")
-		return nil
 	}
 
 	log.Debugf("Successfully got Host for %s", array.GlobalID)
 
 	for _, initiator := range host.Initiators {
 		if len(initiator.ActiveSessions) > 0 {
+			// just in case if we have set useNFS as true earlier when iscsi session were not established
+			if s.useNFS {
+				s.useNFS = false
+			}
+			return nil
+		} else if s.useNFS {
+			log.Infof("Host Entry found but failed to login to nvme/iscsi target, seems to be this worker has only NFS")
 			return nil
 		}
 	}

--- a/pkg/node/node_connectivity_checker.go
+++ b/pkg/node/node_connectivity_checker.go
@@ -226,7 +226,7 @@ func (s *Service) nodeProbe(timeOutCtx context.Context, array *array.PowerStoreA
 
 	for _, initiator := range host.Initiators {
 		if len(initiator.ActiveSessions) > 0 {
-			// just in case if we have set useNFS as true earlier when iscsi session were not established
+			// In case we had set useNFS as true when no ISCSI session was established in NodeGetInfo
 			if s.useNFS {
 				s.useNFS = false
 			}


### PR DESCRIPTION
# Description
Enhancing NodeGetInfo & nodeProbe when iscsi login is failed

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Enabled chap and created pods and pvc and checked the active session on the array, sessions were active, pod and pvc created successfully.
- [x] Ran cert-csi (for iscsi protocol) and UT locally and it passed successfully. 
![image](https://user-images.githubusercontent.com/109620911/216311716-6db03d70-5c9d-480d-bb65-259bea500898.png)
