### PR TITLE
Updated replication extension & sidecar image version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dell/csi-metadata-retriever v1.2.0
 	github.com/dell/dell-csi-extensions/common v1.1.0
 	github.com/dell/dell-csi-extensions/podmon v1.1.1
-	github.com/dell/dell-csi-extensions/replication v1.2.0
+	github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230112204455-8f3445ef5483
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2-0.20220823070737-c80a2164070b
 	github.com/dell/gobrick v1.6.0
 	github.com/dell/gocsi v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/dell/dell-csi-extensions/common v1.1.0 h1:BFWoXdAennOs+fFiYqsGo02AU27
 github.com/dell/dell-csi-extensions/common v1.1.0/go.mod h1:x68COjv2yqphSmGWZDPV9WcBENA9+e8v21aGFO5i3PQ=
 github.com/dell/dell-csi-extensions/podmon v1.1.1 h1:AIFHmVscJInpADaJyXMuvpHZKAhLpQhD+7dFHjHKdjI=
 github.com/dell/dell-csi-extensions/podmon v1.1.1/go.mod h1:J4VNEmXV6sz40QviNF1B+Ov+KNQmzFtJw0YNUpq6ncs=
-github.com/dell/dell-csi-extensions/replication v1.2.0 h1:zOJgSMvZOXl4fVJzP98vh26J2i17cbdMARm2bi/b++w=
-github.com/dell/dell-csi-extensions/replication v1.2.0/go.mod h1:FU2kzS8/29GlK9iCdS+E70cyeWun63eNP44aHwg7jW8=
+github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230112204455-8f3445ef5483 h1:sVMPxFaRBk80s+gwPAtzw1mtcjefDdvv1drkoyK1/kg=
+github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230112204455-8f3445ef5483/go.mod h1:FU2kzS8/29GlK9iCdS+E70cyeWun63eNP44aHwg7jW8=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2-0.20220823070737-c80a2164070b h1:PIKiU3qwTIUb4vSLUghB3hsgbuRUA84jaePt/Ds8r5c=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2-0.20220823070737-c80a2164070b/go.mod h1:etLWwS1G2IqHDuArHqB0OWQvpdcztuBxopWrRE+mpk0=
 github.com/dell/gobrick v1.6.0 h1:U0bfvCVaSCAm3LCoMULY4LOoG9ovrLj8dorwejU/wig=

--- a/helm/csi-powerstore/values.yaml
+++ b/helm/csi-powerstore/values.yaml
@@ -151,7 +151,7 @@ controller:
     # image: Image to use for dell-csi-replicator. This shouldn't be changed
     # Allowed values: string
     # Default value: None
-    image: dellemc/dell-csi-replicator:v1.3.0
+    image: dellemc/dell-csi-replicator:v1.4.0
 
     # replicationContextPrefix: prefix to use for naming of resources created by replication feature
     # Allowed values: string


### PR DESCRIPTION
# Description
- Updated replication extension package version as the extension  (https://github.com/dell/dell-csi-extensions/pull/27) and replication module CRD (https://github.com/dell/csm-replication/pull/75) updated from alpha to v1 version.
- Replicator side car image is updated to v1.4.0.

Note: Since 1.4 replicator side care image is not officially out, please use nightly tag which will be updated when this PR merges.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/432 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?

Tested image deployment before and after the changes (Replicator sidecar container will fail to start without the changes).

```
{"address":"unix:///var/run/csi/csi.sock","level":"info","logger":"setup","msg":"Connecting to","time":"2023-02-09T21:43:01.004593541Z"}
{"level":"info","logger":"setup","msg":"Connected to socket","time":"2023-02-09T21:43:01.005333322Z"}
{"level":"info","logger":"identity-client","msg":"Probing controller","time":"2023-02-09T21:43:01.005368944Z"}
{"error":"rpc error: code = Unimplemented desc = unknown service replication.v1.Replication","level":"error","logger":"setup","msg":"error waiting for the CSI driver to be ready","time":"2023-02-09T21:43:01.006175821Z"}
```
