### PR TITLE
Bugfix/populating targets in cache

### DIFF
--- a/pkg/node/node_connectivity_checker.go
+++ b/pkg/node/node_connectivity_checker.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -225,6 +226,7 @@ func (s *Service) nodeProbe(timeOutCtx context.Context, array *array.PowerStoreA
 	}
 
 	log.Debugf("Successfully got Host on %s", array.GlobalID)
+	s.populateTargetsInCache(array)
 	// check if nvme sessions are active
 	if s.useNVME {
 		log.Debugf("Checking if nvme sessions are active on node or not")
@@ -274,5 +276,82 @@ func (s *Service) nodeProbe(timeOutCtx context.Context, array *array.PowerStoreA
 			return nil
 		}
 		return fmt.Errorf("no active iscsi sessions")
+	}
+}
+
+// populateTargetsInCache checks if nvmeTargets or iscsiTargets in cache is empty, try to fetch the targets from array and populate the cache
+func (s *Service) populateTargetsInCache(array *array.PowerStoreArray) {
+	// if nvmeTargets in cache is empty
+	if s.useNVME {
+		if len(s.nvmeTargets[array.GlobalID]) == 0 {
+			// for NVMeFC
+			if s.useFC {
+				nvmefcInfo, err := common.GetNVMEFCTargetInfoFromStorage(array.GetClient(), "")
+				if err != nil {
+					log.Errorf("couldn't get targets from the array: %s", err.Error())
+					return
+				}
+				for _, info := range nvmefcInfo {
+					NVMeFCTargets, err := s.nvmeLib.DiscoverNVMeFCTargets(info.Portal, false)
+					if err != nil {
+						log.Errorf("couldn't discover NVMeFC targets")
+						continue
+					} else {
+						for _, target := range NVMeFCTargets {
+							otherTargets := s.nvmeTargets[array.GlobalID]
+							s.nvmeTargets[array.GlobalID] = append(otherTargets, target.TargetNqn)
+						}
+					}
+				}
+			} else {
+				infoList, err := common.GetISCSITargetsInfoFromStorage(array.GetClient(), "")
+				if err != nil {
+					log.Errorf("couldn't get targets from array: %s", err.Error())
+					return
+				}
+				var nvmeTargets []gonvme.NVMeTarget
+				for _, address := range infoList {
+					nvmeIP := strings.Split(address.Portal, ":")
+					log.Info("Trying to discover NVMe target from portal ", nvmeIP[0])
+					nvmeTargets, err = s.nvmeLib.DiscoverNVMeTCPTargets(nvmeIP[0], false)
+					if err != nil {
+						log.Error("couldn't discover targets")
+						continue
+					}
+					break
+				}
+				for _, target := range nvmeTargets {
+					otherTargets := s.nvmeTargets[array.GlobalID]
+					s.nvmeTargets[array.GlobalID] = append(otherTargets, target.TargetNqn)
+				}
+			}
+		}
+	} else if !s.useNVME && !s.useFC {
+		infoList, err := common.GetISCSITargetsInfoFromStorage(array.GetClient(), "")
+		if err != nil {
+			log.Errorf("couldn't get targets from array: %s", err.Error())
+			return
+		}
+
+		var iscsiTargets []goiscsi.ISCSITarget
+		for _, address := range infoList {
+			// first check if this portal is reachable from this machine or not
+			if ReachableEndPoint(address.Portal) {
+				// doesn't matter how many portals are present, discovering from any one will list out all targets
+				log.Info("Trying to discover iSCSI target from portal ", address.Portal)
+				iscsiTargets, err = s.iscsiLib.DiscoverTargets(address.Portal, false)
+				if err != nil {
+					log.Error("couldn't discover targets")
+					continue
+				}
+				break
+			} else {
+				log.Debugf("Portal %s is not rechable from the node", address.Portal)
+			}
+		}
+		for _, target := range iscsiTargets {
+			otherTargets := s.iscsiTargets[array.GlobalID]
+			s.iscsiTargets[array.GlobalID] = append(otherTargets, target.Target)
+		}
 	}
 }

--- a/pkg/node/node_connectivity_checker.go
+++ b/pkg/node/node_connectivity_checker.go
@@ -284,78 +284,81 @@ func (s *Service) populateTargetsInCache(array *array.PowerStoreArray) {
 	// if nvmeTargets in cache is empty
 	// this could be empty in 2 cases: Either container is getting restarted or discovery & login has failed in NodeGetInfo
 	if s.useNVME {
-		if len(s.nvmeTargets[array.GlobalID]) == 0 {
-			// for NVMeFC
-			if s.useFC {
-				nvmefcInfo, err := common.GetNVMEFCTargetInfoFromStorage(array.GetClient(), "")
+		if len(s.nvmeTargets[array.GlobalID]) != 0 {
+			return
+		}
+		// for NVMeFC
+		if s.useFC {
+			nvmefcInfo, err := common.GetNVMEFCTargetInfoFromStorage(array.GetClient(), "")
+			if err != nil {
+				log.Errorf("couldn't get targets from the array: %s", err.Error())
+				return
+			}
+			for _, info := range nvmefcInfo {
+				NVMeFCTargets, err := s.nvmeLib.DiscoverNVMeFCTargets(info.Portal, false)
 				if err != nil {
-					log.Errorf("couldn't get targets from the array: %s", err.Error())
-					return
+					log.Errorf("couldn't discover NVMeFC targets")
+					continue
 				}
-				for _, info := range nvmefcInfo {
-					NVMeFCTargets, err := s.nvmeLib.DiscoverNVMeFCTargets(info.Portal, false)
-					if err != nil {
-						log.Errorf("couldn't discover NVMeFC targets")
-						continue
-					} else {
-						for _, target := range NVMeFCTargets {
-							otherTargets := s.nvmeTargets[array.GlobalID]
-							s.nvmeTargets[array.GlobalID] = append(otherTargets, target.TargetNqn)
-						}
-					}
-				}
-			} else {
-				infoList, err := common.GetISCSITargetsInfoFromStorage(array.GetClient(), "")
-				if err != nil {
-					log.Errorf("couldn't get targets from array: %s", err.Error())
-					return
-				}
-				var nvmeTargets []gonvme.NVMeTarget
-				for _, address := range infoList {
-					nvmeIP := strings.Split(address.Portal, ":")
-					log.Info("Trying to discover NVMe target from portal ", nvmeIP[0])
-					nvmeTargets, err = s.nvmeLib.DiscoverNVMeTCPTargets(nvmeIP[0], false)
-					if err != nil {
-						log.Error("couldn't discover targets")
-						continue
-					}
-					break
-				}
-				for _, target := range nvmeTargets {
+				for _, target := range NVMeFCTargets {
 					otherTargets := s.nvmeTargets[array.GlobalID]
 					s.nvmeTargets[array.GlobalID] = append(otherTargets, target.TargetNqn)
 				}
+				break
 			}
-		}
-	} else if !s.useNVME && !s.useFC {
-		// if iscsiTargets in cache is empty
-		if len(s.iscsiTargets[array.GlobalID]) == 0 {
+		} else {
 			infoList, err := common.GetISCSITargetsInfoFromStorage(array.GetClient(), "")
 			if err != nil {
 				log.Errorf("couldn't get targets from array: %s", err.Error())
 				return
 			}
 
-			var iscsiTargets []goiscsi.ISCSITarget
 			for _, address := range infoList {
-				// first check if this portal is reachable from this machine or not
-				if ReachableEndPoint(address.Portal) {
-					// doesn't matter how many portals are present, discovering from any one will list out all targets
-					log.Info("Trying to discover iSCSI target from portal ", address.Portal)
-					iscsiTargets, err = s.iscsiLib.DiscoverTargets(address.Portal, false)
-					if err != nil {
-						log.Error("couldn't discover targets")
-						continue
-					}
-					break
-				} else {
-					log.Debugf("Portal %s is not rechable from the node", address.Portal)
+				nvmeIP := strings.Split(address.Portal, ":")
+				log.Info("Trying to discover NVMe target from portal ", nvmeIP[0])
+				nvmeTargets, err := s.nvmeLib.DiscoverNVMeTCPTargets(nvmeIP[0], false)
+				if err != nil {
+					log.Error("couldn't discover targets")
+					continue
 				}
-			}
-			for _, target := range iscsiTargets {
-				otherTargets := s.iscsiTargets[array.GlobalID]
-				s.iscsiTargets[array.GlobalID] = append(otherTargets, target.Target)
+				for _, target := range nvmeTargets {
+					otherTargets := s.nvmeTargets[array.GlobalID]
+					s.nvmeTargets[array.GlobalID] = append(otherTargets, target.TargetNqn)
+				}
+				break
 			}
 		}
+	} else if !s.useFC && !s.useNFS {
+		// if iscsiTargets in cache is empty
+		if len(s.iscsiTargets[array.GlobalID]) != 0 {
+			return
+		}
+		infoList, err := common.GetISCSITargetsInfoFromStorage(array.GetClient(), "")
+		if err != nil {
+			log.Errorf("couldn't get targets from array: %s", err.Error())
+			return
+		}
+
+		var iscsiTargets []goiscsi.ISCSITarget
+		for _, address := range infoList {
+			// first check if this portal is reachable from this machine or not
+			if ReachableEndPoint(address.Portal) {
+				// doesn't matter how many portals are present, discovering from any one will list out all targets
+				log.Info("Trying to discover iSCSI target from portal ", address.Portal)
+				iscsiTargets, err = s.iscsiLib.DiscoverTargets(address.Portal, false)
+				if err != nil {
+					log.Error("couldn't discover targets")
+					continue
+				}
+				for _, target := range iscsiTargets {
+					otherTargets := s.iscsiTargets[array.GlobalID]
+					s.iscsiTargets[array.GlobalID] = append(otherTargets, target.Target)
+				}
+				break
+			} else {
+				log.Debugf("Portal %s is not rechable from the node", address.Portal)
+			}
+		}
+
 	}
 }

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -634,6 +634,8 @@ var _ = Describe("CSINodeService", func() {
 					}, nil)
 
 				arrays := getTestArrays()
+				clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).
+					Return([]gopowerstore.IPPoolAddress{}, nil)
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
 
 				Expect(err.Error()).To(ContainSubstring("no active iscsi sessions"))
@@ -653,6 +655,8 @@ var _ = Describe("CSINodeService", func() {
 
 				arrays := getTestArrays()
 				nodeSvc.useNVME = true
+				clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).
+					Return([]gopowerstore.IPPoolAddress{}, nil)
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
 				nodeSvc.useNVME = false
 				Expect(err.Error()).To(ContainSubstring("no active nvme sessions"))
@@ -673,6 +677,8 @@ var _ = Describe("CSINodeService", func() {
 							}},
 						Name: "host-name",
 					}, nil)
+				clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).
+					Return([]gopowerstore.IPPoolAddress{}, nil)
 				nodeSvc.useNFS = true
 				arrays := getTestArrays()
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
@@ -695,6 +701,8 @@ var _ = Describe("CSINodeService", func() {
 							}},
 						Name: "host-name",
 					}, nil)
+				clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).
+					Return([]gopowerstore.IPPoolAddress{}, nil)
 				nodeSvc.useNFS = true
 				nodeSvc.useNVME = true
 				arrays := getTestArrays()
@@ -733,7 +741,8 @@ var _ = Describe("CSINodeService", func() {
 							}},
 						Name: "host-name",
 					}, nil)
-
+				clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).
+					Return([]gopowerstore.IPPoolAddress{}, nil)
 				arrays := getTestArrays()
 				nodeSvc.useNFS = true
 				nodeSvc.iscsiTargets["unique"] = []string{"iqn.2015-10.com.dell:dellemc-foobar-123-a-7ceb34a0"}
@@ -772,7 +781,8 @@ var _ = Describe("CSINodeService", func() {
 							}},
 						Name: "host-name",
 					}, nil)
-
+				clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).
+					Return([]gopowerstore.IPPoolAddress{}, nil)
 				arrays := getTestArrays()
 				nodeSvc.useNFS = true
 				nodeSvc.useNVME = true
@@ -801,7 +811,8 @@ var _ = Describe("CSINodeService", func() {
 							}},
 						Name: "host-name",
 					}, nil)
-
+				clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).
+					Return([]gopowerstore.IPPoolAddress{}, nil)
 				arrays := getTestArrays()
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
 				Expect(err.Error()).To(ContainSubstring("no active iscsi sessions"))


### PR DESCRIPTION
# Description
Populating iscsi/nvme target's list in cache in case if list is empty.
In case if driver container is getting restarted then iscsi/nvme targets will gets flushed from cache and we used to populate them inside NodeGetInfo. However, NodeGetInfo will not be called again after the container restarts. Therefore, we need to check if the cache is empty and repopulate it inside nodeProbe.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| https://github.com/dell/csm/issues/587 |


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran make test to make sure existing UT work fine.
![image](https://user-images.githubusercontent.com/109620911/221536978-39c48521-31fe-42c2-9e2c-d67fa7e177b0.png)

