### PR TITLE
Added stub for new DeleteLocalVolume gRPC call

### DIFF
--- a/docker-files/Dockerfile.ubi.min
+++ b/docker-files/Dockerfile.ubi.min
@@ -29,6 +29,24 @@ LABEL vendor="Dell Inc." \
 
 COPY licenses /licenses
 
+RUN echo $'[rhel-8-baseos] \n\
+name=Red Hat Enterprise Linux 8 (BaseOS) - $basearch \n\
+baseurl=http://hb.us.dell.com/pub/redhat/RHEL8/stable/BaseOS/x86_64/os/ \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta \n\
+skip_if_unavailable=1' > /etc/yum.repos.d/dell-rpm.repo
+
+
+RUN echo $'[rhel-8-appstream] \n\
+name=Red Hat Enterprise Linux 8 (AppStream) - $basearch \n\
+baseurl=http://hb.us.dell.com/pub/redhat/RHEL8/stable/AppStream/x86_64/os/ \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta \n\
+skip_if_unavailable=1' >> /etc/yum.repos.d/dell-rpm.repo
+
+
 # dependencies, following by cleaning the cache
 RUN microdnf update -y \
     && \

--- a/docker-files/Dockerfile.ubi.min
+++ b/docker-files/Dockerfile.ubi.min
@@ -29,24 +29,6 @@ LABEL vendor="Dell Inc." \
 
 COPY licenses /licenses
 
-RUN echo $'[rhel-8-baseos] \n\
-name=Red Hat Enterprise Linux 8 (BaseOS) - $basearch \n\
-baseurl=http://hb.us.dell.com/pub/redhat/RHEL8/stable/BaseOS/x86_64/os/ \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta \n\
-skip_if_unavailable=1' > /etc/yum.repos.d/dell-rpm.repo
-
-
-RUN echo $'[rhel-8-appstream] \n\
-name=Red Hat Enterprise Linux 8 (AppStream) - $basearch \n\
-baseurl=http://hb.us.dell.com/pub/redhat/RHEL8/stable/AppStream/x86_64/os/ \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta \n\
-skip_if_unavailable=1' >> /etc/yum.repos.d/dell-rpm.repo
-
-
 # dependencies, following by cleaning the cache
 RUN microdnf update -y \
     && \

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dell/csi-metadata-retriever v1.3.0
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.0
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gobrick v1.7.0
 	github.com/dell/gocsi v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dell/csi-metadata-retriever v1.3.0
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gobrick v1.7.0
 	github.com/dell/gocsi v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dell/csi-metadata-retriever v1.3.0
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gobrick v1.7.0
 	github.com/dell/gocsi v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/dell/dell-csi-extensions/common v1.1.1 h1:PXdqCm6lL1g02KuR9SrsrZeoTk6
 github.com/dell/dell-csi-extensions/common v1.1.1/go.mod h1:eHfx1rwttqdPZBy8cfvRbJYPElGa/NY4fRR/P//yndw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7hPY6nPkRAyFh0slw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0 h1:8puwDAHQI+SI9KoKigJARxmwRE1tk40zRFekt6WQQ/o=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gobrick v1.7.0 h1:XM72GhtyIKpBuj/yjTr3N04uWLFNMyDjXjDGjgCmtno=

--- a/go.sum
+++ b/go.sum
@@ -128,10 +128,8 @@ github.com/dell/dell-csi-extensions/common v1.1.1 h1:PXdqCm6lL1g02KuR9SrsrZeoTk6
 github.com/dell/dell-csi-extensions/common v1.1.1/go.mod h1:eHfx1rwttqdPZBy8cfvRbJYPElGa/NY4fRR/P//yndw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7hPY6nPkRAyFh0slw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
-github.com/dell/dell-csi-extensions/replication v1.3.0 h1:Z2w+jwoyBM4ESKhABLeRjIcWxJMd4Bnt3phEPeQhljw=
-github.com/dell/dell-csi-extensions/replication v1.3.0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c h1:YRaaqDtQuSMrhRPIMVr+RJuaZwm6y0W1zecO7a7cyj8=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gobrick v1.7.0 h1:XM72GhtyIKpBuj/yjTr3N04uWLFNMyDjXjDGjgCmtno=

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
 github.com/dell/dell-csi-extensions/replication v1.3.0 h1:Z2w+jwoyBM4ESKhABLeRjIcWxJMd4Bnt3phEPeQhljw=
 github.com/dell/dell-csi-extensions/replication v1.3.0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c h1:YRaaqDtQuSMrhRPIMVr+RJuaZwm6y0W1zecO7a7cyj8=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gobrick v1.7.0 h1:XM72GhtyIKpBuj/yjTr3N04uWLFNMyDjXjDGjgCmtno=

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -507,11 +507,12 @@ func (s *Service) DeleteStorageProtectionGroup(ctx context.Context,
 	return &csiext.DeleteStorageProtectionGroupResponse{}, nil
 }
 
-// TODO: implement
+// DeleteLocalVolume deletes a volume on the local storage array upon request from a remote replication controller.
 func (s *Service) DeleteLocalVolume(ctx context.Context,
 	req *csiext.DeleteLocalVolumeRequest) (*csiext.DeleteLocalVolumeResponse, error) {
+	// TODO: Implement this at the driver level.
 
-	log.Info("!!! Deleting Local Volume !!!")
+	log.Info("Deleting Local Volume " + req.VolumeHandle)
 
 	return &csiext.DeleteLocalVolumeResponse{}, nil
 }

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -507,6 +507,15 @@ func (s *Service) DeleteStorageProtectionGroup(ctx context.Context,
 	return &csiext.DeleteStorageProtectionGroupResponse{}, nil
 }
 
+// TODO: implement
+func (s *Service) DeleteRemoteVolume(ctx context.Context,
+	req *csiext.DeleteRemoteVolumeRequest) (*csiext.DeleteRemoteVolumeResponse, error) {
+
+	log.Info("!!! Deleting Remote Volume !!!")
+
+	return &csiext.DeleteRemoteVolumeResponse{}, nil
+}
+
 // GetStorageProtectionGroupStatus gets storage protection group status
 func (s *Service) GetStorageProtectionGroupStatus(ctx context.Context,
 	req *csiext.GetStorageProtectionGroupStatusRequest) (*csiext.GetStorageProtectionGroupStatusResponse, error) {

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -508,12 +508,12 @@ func (s *Service) DeleteStorageProtectionGroup(ctx context.Context,
 }
 
 // TODO: implement
-func (s *Service) DeleteRemoteVolume(ctx context.Context,
-	req *csiext.DeleteRemoteVolumeRequest) (*csiext.DeleteRemoteVolumeResponse, error) {
+func (s *Service) DeleteLocalVolume(ctx context.Context,
+	req *csiext.DeleteLocalVolumeRequest) (*csiext.DeleteLocalVolumeResponse, error) {
 
-	log.Info("!!! Deleting Remote Volume !!!")
+	log.Info("!!! Deleting Local Volume !!!")
 
-	return &csiext.DeleteRemoteVolumeResponse{}, nil
+	return &csiext.DeleteLocalVolumeResponse{}, nil
 }
 
 // GetStorageProtectionGroupStatus gets storage protection group status


### PR DESCRIPTION
# Description
Stub added for DeleteLocalVolume, new gRPC call to allow for deletion of backend volume. 

Driver-level implementation of DeleteLocalVolume to follow. PR is set as draft for now.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| [665](https://github.com/dell/csm/issues/665) |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Usage of the new gRPC call and annotation has been tested with the replication CSM module. Annotations were applied and edited as expected, and remote PVs were deleted as expected. 