### PR TITLE
Feature/delete local vol implementation

### DIFF
--- a/docker-files/Dockerfile.ubi.min
+++ b/docker-files/Dockerfile.ubi.min
@@ -29,6 +29,24 @@ LABEL vendor="Dell Inc." \
 
 COPY licenses /licenses
 
+RUN echo $'[rhel-8-baseos] \n\
+name=Red Hat Enterprise Linux 8 (BaseOS) - $basearch \n\
+baseurl=http://hb.us.dell.com/pub/redhat/RHEL8/stable/BaseOS/x86_64/os/ \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta \n\
+skip_if_unavailable=1' > /etc/yum.repos.d/dell-rpm.repo
+
+
+RUN echo $'[rhel-8-appstream] \n\
+name=Red Hat Enterprise Linux 8 (AppStream) - $basearch \n\
+baseurl=http://hb.us.dell.com/pub/redhat/RHEL8/stable/AppStream/x86_64/os/ \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta \n\
+skip_if_unavailable=1' >> /etc/yum.repos.d/dell-rpm.repo
+
+
 # dependencies, following by cleaning the cache
 RUN microdnf update -y \
     && \

--- a/docker-files/Dockerfile.ubi.min
+++ b/docker-files/Dockerfile.ubi.min
@@ -29,24 +29,6 @@ LABEL vendor="Dell Inc." \
 
 COPY licenses /licenses
 
-RUN echo $'[rhel-8-baseos] \n\
-name=Red Hat Enterprise Linux 8 (BaseOS) - $basearch \n\
-baseurl=http://hb.us.dell.com/pub/redhat/RHEL8/stable/BaseOS/x86_64/os/ \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta \n\
-skip_if_unavailable=1' > /etc/yum.repos.d/dell-rpm.repo
-
-
-RUN echo $'[rhel-8-appstream] \n\
-name=Red Hat Enterprise Linux 8 (AppStream) - $basearch \n\
-baseurl=http://hb.us.dell.com/pub/redhat/RHEL8/stable/AppStream/x86_64/os/ \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta \n\
-skip_if_unavailable=1' >> /etc/yum.repos.d/dell-rpm.repo
-
-
 # dependencies, following by cleaning the cache
 RUN microdnf update -y \
     && \

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dell/csi-metadata-retriever v1.3.0
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.0
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gobrick v1.7.0
 	github.com/dell/gocsi v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dell/csi-metadata-retriever v1.3.0
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gobrick v1.7.0
 	github.com/dell/gocsi v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dell/csi-metadata-retriever v1.3.0
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gobrick v1.7.0
 	github.com/dell/gocsi v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/dell/dell-csi-extensions/common v1.1.1 h1:PXdqCm6lL1g02KuR9SrsrZeoTk6
 github.com/dell/dell-csi-extensions/common v1.1.1/go.mod h1:eHfx1rwttqdPZBy8cfvRbJYPElGa/NY4fRR/P//yndw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7hPY6nPkRAyFh0slw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0 h1:8puwDAHQI+SI9KoKigJARxmwRE1tk40zRFekt6WQQ/o=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gobrick v1.7.0 h1:XM72GhtyIKpBuj/yjTr3N04uWLFNMyDjXjDGjgCmtno=

--- a/go.sum
+++ b/go.sum
@@ -128,10 +128,8 @@ github.com/dell/dell-csi-extensions/common v1.1.1 h1:PXdqCm6lL1g02KuR9SrsrZeoTk6
 github.com/dell/dell-csi-extensions/common v1.1.1/go.mod h1:eHfx1rwttqdPZBy8cfvRbJYPElGa/NY4fRR/P//yndw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7hPY6nPkRAyFh0slw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
-github.com/dell/dell-csi-extensions/replication v1.3.0 h1:Z2w+jwoyBM4ESKhABLeRjIcWxJMd4Bnt3phEPeQhljw=
-github.com/dell/dell-csi-extensions/replication v1.3.0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c h1:YRaaqDtQuSMrhRPIMVr+RJuaZwm6y0W1zecO7a7cyj8=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gobrick v1.7.0 h1:XM72GhtyIKpBuj/yjTr3N04uWLFNMyDjXjDGjgCmtno=

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
 github.com/dell/dell-csi-extensions/replication v1.3.0 h1:Z2w+jwoyBM4ESKhABLeRjIcWxJMd4Bnt3phEPeQhljw=
 github.com/dell/dell-csi-extensions/replication v1.3.0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c h1:YRaaqDtQuSMrhRPIMVr+RJuaZwm6y0W1zecO7a7cyj8=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gobrick v1.7.0 h1:XM72GhtyIKpBuj/yjTr3N04uWLFNMyDjXjDGjgCmtno=

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -3653,7 +3653,7 @@ var _ = Describe("CSIControllerService", func() {
 					Return(gopowerstore.Cluster{Name: validClusterName}, nil)
 
 				clientMock.On("GetRemoteSystem", mock.Anything, validRemoteSystemID).
-					Return(gopowerstore.RemoteSystem{Name: validRemoteSystemName, ManagementAddress: secondValidID}, nil)
+					Return(gopowerstore.RemoteSystem{Name: validRemoteSystemName, ManagementAddress: secondValidID, ID: validRemoteSystemID}, nil)
 
 				req := &csiext.CreateRemoteVolumeRequest{
 					VolumeHandle: validBaseVolID + "/" + firstValidID + "/" + "iscsi",
@@ -3665,10 +3665,11 @@ var _ = Describe("CSIControllerService", func() {
 				Expect(res).To(Equal(
 					&csiext.CreateRemoteVolumeResponse{RemoteVolume: &csiext.Volume{
 						CapacityBytes: validVolSize,
-						VolumeId:      validRemoteVolId + "/" + secondValidID + "/" + "iscsi",
+						VolumeId:      validRemoteVolId + "/" + validRemoteSystemID + "/" + "iscsi",
 						VolumeContext: map[string]string{
 							"remoteSystem":      validClusterName,
 							"managementAddress": secondValidID,
+							"arrayID":           validRemoteSystemID,
 						},
 					}}))
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -3653,7 +3653,7 @@ var _ = Describe("CSIControllerService", func() {
 					Return(gopowerstore.Cluster{Name: validClusterName}, nil)
 
 				clientMock.On("GetRemoteSystem", mock.Anything, validRemoteSystemID).
-					Return(gopowerstore.RemoteSystem{Name: validRemoteSystemName, ManagementAddress: secondValidID, ID: validRemoteSystemID}, nil)
+					Return(gopowerstore.RemoteSystem{Name: validRemoteSystemName, ManagementAddress: secondValidID, ID: validRemoteSystemID, SerialNumber: validRemoteSystemGlobalID}, nil)
 
 				req := &csiext.CreateRemoteVolumeRequest{
 					VolumeHandle: validBaseVolID + "/" + firstValidID + "/" + "iscsi",
@@ -3665,11 +3665,11 @@ var _ = Describe("CSIControllerService", func() {
 				Expect(res).To(Equal(
 					&csiext.CreateRemoteVolumeResponse{RemoteVolume: &csiext.Volume{
 						CapacityBytes: validVolSize,
-						VolumeId:      validRemoteVolId + "/" + validRemoteSystemID + "/" + "iscsi",
+						VolumeId:      validRemoteVolId + "/" + validRemoteSystemGlobalID + "/" + "iscsi",
 						VolumeContext: map[string]string{
 							"remoteSystem":      validClusterName,
 							"managementAddress": secondValidID,
-							"arrayID":           validRemoteSystemID,
+							"arrayID":           validRemoteSystemGlobalID,
 						},
 					}}))
 

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -507,11 +507,12 @@ func (s *Service) DeleteStorageProtectionGroup(ctx context.Context,
 	return &csiext.DeleteStorageProtectionGroupResponse{}, nil
 }
 
-// TODO: implement
+// DeleteLocalVolume deletes a volume on the local storage array upon request from a remote replication controller.
 func (s *Service) DeleteLocalVolume(ctx context.Context,
 	req *csiext.DeleteLocalVolumeRequest) (*csiext.DeleteLocalVolumeResponse, error) {
+	// TODO: Implement this at the driver level.
 
-	log.Info("!!! Deleting Local Volume !!!")
+	log.Info("Deleting Local Volume " + req.VolumeHandle)
 
 	return &csiext.DeleteLocalVolumeResponse{}, nil
 }

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -559,7 +559,7 @@ func (s *Service) DeleteLocalVolume(ctx context.Context,
 
 	_, err = arr.GetClient().DeleteVolume(ctx, nil, volumeID)
 	if err != nil {
-		if apiErr, ok := err.(gopowerstore.APIError); ok && !apiErr.NotFound() {
+		if apiErr, ok := err.(gopowerstore.APIError); !ok || !apiErr.NotFound() {
 			log.Info("Cannot delete local volume " + volumeID + ", deletion returned a non-404 error code.")
 			return nil, status.Errorf(codes.Internal, "Error: Unable to delete volume")
 		}

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -524,7 +524,7 @@ func (s *Service) DeleteLocalVolume(ctx context.Context,
 
 	arr, ok := s.Arrays()[globalID]
 	if !ok {
-		return nil, status.Errorf(codes.InvalidArgument, "can't find array with global id %s", globalID)
+		return nil, status.Errorf(codes.InvalidArgument, "can't find array with global ID %s", globalID)
 	}
 
 	vol, err := arr.GetClient().GetVolume(ctx, volumeID)
@@ -558,9 +558,11 @@ func (s *Service) DeleteLocalVolume(ctx context.Context,
 	}
 
 	_, err = arr.GetClient().DeleteVolume(ctx, nil, volumeID)
-	if apiErr, ok := err.(gopowerstore.APIError); ok && !apiErr.NotFound() {
-		log.Info("Unable to delete local volume. Something went wrong.")
-		return nil, status.Errorf(codes.Internal, "Error: Unable to delete volume")
+	if err != nil {
+		if apiErr, ok := err.(gopowerstore.APIError); ok && !apiErr.NotFound() {
+			log.Info("Cannot delete local volume " + volumeID + ", deletion returned a non-404 error code.")
+			return nil, status.Errorf(codes.Internal, "Error: Unable to delete volume")
+		}
 	}
 
 	log.Info("Local volume deleted successfully.")

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -507,6 +507,15 @@ func (s *Service) DeleteStorageProtectionGroup(ctx context.Context,
 	return &csiext.DeleteStorageProtectionGroupResponse{}, nil
 }
 
+// TODO: implement
+func (s *Service) DeleteRemoteVolume(ctx context.Context,
+	req *csiext.DeleteRemoteVolumeRequest) (*csiext.DeleteRemoteVolumeResponse, error) {
+
+	log.Info("!!! Deleting Remote Volume !!!")
+
+	return &csiext.DeleteRemoteVolumeResponse{}, nil
+}
+
 // GetStorageProtectionGroupStatus gets storage protection group status
 func (s *Service) GetStorageProtectionGroupStatus(ctx context.Context,
 	req *csiext.GetStorageProtectionGroupStatusRequest) (*csiext.GetStorageProtectionGroupStatusResponse, error) {

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -532,7 +532,7 @@ func (s *Service) DeleteLocalVolume(ctx context.Context,
 		if apiError, ok := err.(gopowerstore.APIError); ok {
 			if apiError.NotFound() {
 				// volume doesn't exist, return success
-				log.Info(("Volume does not exist. It may have already been deleted."))
+				log.Info("Volume does not exist. It may have already been deleted.")
 				return &csiext.DeleteLocalVolumeResponse{}, nil
 			}
 		}

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -508,12 +508,12 @@ func (s *Service) DeleteStorageProtectionGroup(ctx context.Context,
 }
 
 // TODO: implement
-func (s *Service) DeleteRemoteVolume(ctx context.Context,
-	req *csiext.DeleteRemoteVolumeRequest) (*csiext.DeleteRemoteVolumeResponse, error) {
+func (s *Service) DeleteLocalVolume(ctx context.Context,
+	req *csiext.DeleteLocalVolumeRequest) (*csiext.DeleteLocalVolumeResponse, error) {
 
-	log.Info("!!! Deleting Remote Volume !!!")
+	log.Info("!!! Deleting Local Volume !!!")
 
-	return &csiext.DeleteRemoteVolumeResponse{}, nil
+	return &csiext.DeleteLocalVolumeResponse{}, nil
 }
 
 // GetStorageProtectionGroupStatus gets storage protection group status

--- a/pkg/controller/replication_test.go
+++ b/pkg/controller/replication_test.go
@@ -18,6 +18,8 @@ package controller_test
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/dell/csi-powerstore/v2/pkg/array"
 	"github.com/dell/csi-powerstore/v2/pkg/controller"
 	csiext "github.com/dell/dell-csi-extensions/replication"
@@ -28,7 +30,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"net/http"
 )
 
 var _ = Describe("Replication", func() {
@@ -395,6 +396,34 @@ var _ = Describe("Replication", func() {
 
 			})
 
+		})
+
+		Describe("calling DeleteLocalVolume()", func() {
+			When("Volume ID is missing", func() {
+				It("should fail", func() {
+					req := new(csiext.DeleteLocalVolumeRequest)
+					res, err := ctrlSvc.DeleteLocalVolume(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("can't delete volume of improper handle format"))
+				})
+			})
+			When("Array with specified globalID couldn't be found", func() {
+				It("should fail", func() {
+
+					req := new(csiext.DeleteLocalVolumeRequest)
+					handle := "valid-id/SOMETHING-WRONG/iscsi"
+					req.VolumeHandle = handle
+					res, err := ctrlSvc.DeleteLocalVolume(context.Background(), req)
+
+					Expect(res).To(BeNil())
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(
+						ContainSubstring("can't find array with global ID"))
+				})
+			})
 		})
 		Describe("calling DeleteStorageProtectionGroup()", func() {
 			When("GlobalID is missing", func() {


### PR DESCRIPTION
# Description
Driver-level implementation of DeleteLocalVolume on PowerStore.[ Corresponds to this PR](https://github.com/dell/csi-powerstore/pull/228), which added the stub. 

PR is set as draft for now.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| [665](https://github.com/dell/csm/issues/665) |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Manual testing to verify that the backend volume is deleted. String of calls from driver logs are as follows:

Source side controller: 

```
{"level":"info","logger":"controllers.PersistentVolume","msg":"Deletion requested annotation not found","persistentvolume":"ccoff-csivol-bd07f02cb9","time":"2023-03-27T18:21:34.409949534Z"}
{"level":"info","logger":"controllers.PersistentVolume","msg":"Retention policy is set to Delete","persistentvolume":"ccoff-csivol-bd07f02cb9","time":"2023-03-27T18:21:34.412726422Z"}
{"level":"info","logger":"controllers.PersistentVolume","msg":"Adding deletion requested annotation to remote volume","persistentvolume":"ccoff-csivol-bd07f02cb9","time":"2023-03-27T18:21:34.412764601Z"}
{"level":"info","logger":"controllers.PersistentVolume","msg":"Adding sync delete annotation to remote","persistentvolume":"ccoff-csivol-bd07f02cb9","time":"2023-03-27T18:21:34.412775669Z"}
{"level":"info","logger":"controllers.PersistentVolume","msg":"Reconciling PV event","time":"2023-03-27T18:21:34.418976533Z"}
```

Target side replicator:

```
{"level":"info","logger":"controllers.PersistentVolume","msg":"Synchronized Deletion requested by annotation, deleting local backend volume","persistentvolume":"{\"Namespace\":\"\",\"Name\":\"ccoff-csivol-bd07f02cb9\"}","time":"2023-03-27T18:21:34.421301732Z"}
{"error":"Operation cannot be fulfilled on persistentvolumes \"ccoff-csivol-bd07f02cb9\": the object has been modified; please apply your changes to the latest version and try again","level":"error","logger":"controllers.PersistentVolume","msg":"Failed to add SynchronizedDeletionStatus complete annotation to the PV","persistentvolume":"{\"Namespace\":\"\",\"Name\":\"ccoff-csivol-bd07f02cb9\"}","time":"2023-03-27T18:21:35.28659685Z"}
{"controller":"persistentvolume","controllerGroup":"","controllerKind":"PersistentVolume","error":"Operation cannot be fulfilled on persistentvolumes \"ccoff-csivol-bd07f02cb9\": the object has been modified; please apply your changes to the latest version and try again","level":"error","msg":"Reconciler error","name":"ccoff-csivol-bd07f02cb9","namespace":"","persistentVolume":"{\"name\":\"ccoff-csivol-bd07f02cb9\"}","reconcileID":"\"122053ad-57fc-4edf-810a-abff1a316b9c\"","time":"2023-03-27T18:21:35.286662832Z"}
{"level":"info","logger":"controllers.PersistentVolume","msg":"Begin reconcile - PV Controller","persistentvolume":"{\"Namespace\":\"\",\"Name\":\"ccoff-csivol-bd07f02cb9\"}","time":"2023-03-27T18:21:35.286755626Z"}
{"level":"info","logger":"controllers.PersistentVolume","msg":"Adding replication-group, remote storage class annotation and label to the PersistentVolume","persistentvolume":"{\"Namespace\":\"\",\"Name\":\"ccoff-csivol-bd07f02cb9\"}","time":"2023-03-27T18:21:35.286835217Z"}
{"level":"debug","logger":"controllers.PersistentVolume","msg":"Checking if PV protection complete annotation is applied","persistentvolume":"{\"Namespace\":\"\",\"Name\":\"ccoff-csivol-bd07f02cb9\"}","time":"2023-03-27T18:21:35.286878691Z"}
{"level":"debug","logger":"controllers.PersistentVolume","msg":"Checking if synchronized deletion annotation is applied","persistentvolume":"{\"Namespace\":\"\",\"Name\":\"ccoff-csivol-bd07f02cb9\"}","time":"2023-03-27T18:21:35.286894258Z"}
{"level":"info","logger":"controllers.PersistentVolume","msg":"Synchronized Deletion requested by annotation, deleting local backend volume","persistentvolume":"{\"Namespace\":\"\",\"Name\":\"ccoff-csivol-bd07f02cb9\"}","time":"2023-03-27T18:21:35.286902148Z"}
```

Target side driver:

```
{"level":"info","msg":"/replication.v1.Replication/DeleteLocalVolume: REQ 0043: VolumeHandle=d76429e0-b1c7-497d-94f4-e78e7fd68498/PS721697ac108a/scsi, VolumeAttributes=map[arrayID:PS721697ac108a replication.storage.dell.com/ignoreNamespaces:false replication.storage.dell.com/isReplicationEnabled:true replication.storage.dell.com/remoteClusterID:ccoff-k8s replication.storage.dell.com/remotePVRetentionPolicy:Delete replication.storage.dell.com/remoteRGRetentionPolicy:Delete replication.storage.dell.com/remoteStorageClassName:pstore-rep-src replication.storage.dell.com/remoteSystem:WX-9023 replication.storage.dell.com/rpo:Five_Minutes replication.storage.dell.com/volumeGroupPrefix:ccoff-csi]","time":"2023-03-27T18:21:34.421746661Z"}
{"level":"info","msg":"Deleting local volume d76429e0-b1c7-497d-94f4-e78e7fd68498/PS721697ac108a/scsi per request from remote replication controller","time":"2023-03-27T18:21:34.421918765Z"}
{"level":"debug","msg":"REQUEST: GET /api/rest/volume/d76429e0-b1c7-497d-94f4-e78e7fd68498?select=%2A HTTP/1.1 Host: 10.230.24.67 Application-Type: CSI Driver for Dell EMC PowerStore/2.6.0+dirty Authorization: ******  ","time":"2023-03-27T18:21:34.422247109Z"}
{"level":"debug","msg":"acquire a lock","time":"2023-03-27T18:21:34.422347894Z"}
{"level":"debug","msg":"RESPONSE: HTTP/1.1 200 OK Content-Length: 1134 Cache-Control: no-cache Cache-Control: no-store Cache-Control: must-revalidate Cache-Control: max-age=0 Content-Language: en-US Content-Type: application/json Dell-Emc-Token: ****** Expires: -1 Set-Cookie: auth_cookie=******; Path=/; Secure; HTTPOnly X-Content-Type-Options: nosniff  {\"id\":\"d76429e0-b1c7-497d-94f4-e78e7fd68498\",\"name\":\"ccoff-csivol-bd07f02cb9\",\"description\":\"test-pvc-default\",\"type\":\"Primary\",\"wwn\":\"naa.68ccf098000fc284411fa4125e0d24bf\",\"nsid\":3176,\"nguid\":\"nguid.0fc284411fa4125e8ccf0968000d24bf\",\"appliance_id\":\"A1\",\"state\":\"Ready\",\"size\":5368709120,\"logical_used\":0,\"node_affinity\":\"System_Select_At_Attach\",\"creation_timestamp\":\"2023-03-27T17:32:25.047902+00:00\",\"protection_policy_id\":null,\"performance_policy_id\":\"default_medium\",\"is_replication_destination\":true,\"migration_session_id\":null,\"metro_replication_session_id\":null,\"is_host_access_available\":true,\"protection_data\":{\"family_id\": \"d76429e0-b1c7-497d-94f4-e78e7fd68498\", \"parent_id\": null, \"source_id\": null, \"creator_type\": \"User\", \"copy_signature\": null, \"source_timestamp\": \"2023-03-27T18:17:40.474399+00:00\", \"creator_type_l10n\": \"User\", \"is_app_consistent\": false, \"created_by_rule_id\": null, \"created_by_rule_name\": null, \"expiration_timestamp\": null},\"location_history\":null,\"app_type\":null,\"app_type_other\":null,\"type_l10n\":\"Primary\",\"state_l10n\":\"Ready\",\"node_affinity_l10n\":\"System Select At Attach\",\"app_type_l10n\":null}\n","time":"2023-03-27T18:21:34.501491619Z"}
{"level":"debug","msg":"release a lock","time":"2023-03-27T18:21:34.501990607Z"}
{"level":"debug","msg":"REQUEST: GET /api/rest/volume/d76429e0-b1c7-497d-94f4-e78e7fd68498?select=volume_group.volume_group_membership%28id%2Cname%2Cprotection_policy_id%29 HTTP/1.1 Host: 10.230.24.67 Application-Type: CSI Driver for Dell EMC PowerStore/2.6.0+dirty Authorization: ******  ","time":"2023-03-27T18:21:34.502078223Z"}
{"level":"debug","msg":"acquire a lock","time":"2023-03-27T18:21:34.502121033Z"}
{"level":"debug","msg":"RESPONSE: HTTP/1.1 200 OK Content-Length: 19 Cache-Control: no-cache Cache-Control: no-store Cache-Control: must-revalidate Cache-Control: max-age=0 Content-Language: en-US Content-Type: application/json Dell-Emc-Token: ****** Expires: -1 Set-Cookie: auth_cookie=******; Path=/; Secure; HTTPOnly X-Content-Type-Options: nosniff  {\"volume_group\":[]}\n","time":"2023-03-27T18:21:34.548834189Z"}
{"level":"debug","msg":"release a lock","time":"2023-03-27T18:21:34.548923433Z"}
{"level":"info","msg":"{[]}","time":"2023-03-27T18:21:34.549174853Z"}
{"level":"debug","msg":"REQUEST: DELETE /api/rest/volume/d76429e0-b1c7-497d-94f4-e78e7fd68498 HTTP/1.1 Host: 10.230.24.67 Application-Type: CSI Driver for Dell EMC PowerStore/2.6.0+dirty Authorization: ******  ","time":"2023-03-27T18:21:34.549288062Z"}
{"level":"debug","msg":"acquire a lock","time":"2023-03-27T18:21:34.549318168Z"}
{"level":"debug","msg":"RESPONSE: HTTP/1.1 204 No Content Cache-Control: no-cache Cache-Control: no-store Cache-Control: must-revalidate Cache-Control: max-age=0 Content-Language: en-US Content-Type: application/json Dell-Emc-Token: ****** Expires: -1 Set-Cookie: auth_cookie=******; Path=/; Secure; HTTPOnly X-Content-Type-Options: nosniff  \n","time":"2023-03-27T18:21:35.281151047Z"}
{"level":"debug","msg":"release a lock","time":"2023-03-27T18:21:35.281190205Z"}
{"level":"info","msg":"Local volume deleted successfully.","time":"2023-03-27T18:21:35.281197462Z"}
{"level":"info","msg":"/replication.v1.Replication/DeleteLocalVolume: REP 0043","time":"2023-03-27T18:21:35.281230758Z"}
{"level":"info","msg":"/replication.v1.Replication/DeleteLocalVolume: REQ 0044: VolumeHandle=d76429e0-b1c7-497d-94f4-e78e7fd68498/PS721697ac108a/scsi, VolumeAttributes=map[arrayID:PS721697ac108a replication.storage.dell.com/ignoreNamespaces:false replication.storage.dell.com/isReplicationEnabled:true replication.storage.dell.com/remoteClusterID:ccoff-k8s replication.storage.dell.com/remotePVRetentionPolicy:Delete replication.storage.dell.com/remoteRGRetentionPolicy:Delete replication.storage.dell.com/remoteStorageClassName:pstore-rep-src replication.storage.dell.com/remoteSystem:WX-9023 replication.storage.dell.com/rpo:Five_Minutes replication.storage.dell.com/volumeGroupPrefix:ccoff-csi]","time":"2023-03-27T18:21:35.287278331Z"}
{"level":"info","msg":"Deleting local volume d76429e0-b1c7-497d-94f4-e78e7fd68498/PS721697ac108a/scsi per request from remote replication controller","time":"2023-03-27T18:21:35.287311735Z"}
{"level":"debug","msg":"REQUEST: GET /api/rest/volume/d76429e0-b1c7-497d-94f4-e78e7fd68498?select=%2A HTTP/1.1 Host: 10.230.24.67 Application-Type: CSI Driver for Dell EMC PowerStore/2.6.0+dirty Authorization: ******  ","time":"2023-03-27T18:21:35.287440842Z"}
{"level":"debug","msg":"acquire a lock","time":"2023-03-27T18:21:35.287454159Z"}
{"level":"debug","msg":"RESPONSE: HTTP/1.1 404 Not Found Content-Length: 198 Cache-Control: no-cache Cache-Control: no-store Cache-Control: must-revalidate Cache-Control: max-age=0 Content-Type: application/json Dell-Emc-Token: ****** Expires: -1 X-Content-Type-Options: nosniff  {\"messages\":[{\"code\":\"0xE04040020009\",\"severity\":\"Error\",\"message_l10n\":\"Instance with id d76429e0-b1c7-497d-94f4-e78e7fd68498 was not found.\",\"arguments\":[\"d76429e0-b1c7-497d-94f4-e78e7fd68498\"]}]}\n","time":"2023-03-27T18:21:35.332258501Z"}
{"level":"debug","msg":"release a lock","time":"2023-03-27T18:21:35.33235969Z"}
{"level":"info","msg":"Volume does not exist. It may have already been deleted.","time":"2023-03-27T18:21:35.332375532Z"}
{"level":"info","msg":"/replication.v1.Replication/DeleteLocalVolume: REP 0044","time":"2023-03-27T18:21:35.332401186Z"}
```

Note: It looks like something in the replicator is failing to update the PV on the first pass, which causes DeleteLocalVolume to run twice. The second run is a NOP because the backend volume is already deleted, as per the last lines in the driver log. It should be addressed in the replicator. 