### PR TITLE
Updating Kubernetes images registry to registry.k8s.io

### DIFF
--- a/helm/csi-powerstore/templates/_helpers.tpl
+++ b/helm/csi-powerstore/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-powerstore.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-attacher:v4.2.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.2.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -12,7 +12,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-powerstore.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -20,7 +20,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-powerstore.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -28,7 +28,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-powerstore.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.7.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.7.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -36,7 +36,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-powerstore.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.3" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -44,7 +44,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-powerstore.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Description
Updating Kubernetes images registry from k8s.gcr.io to registry.k8s.io

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/744|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Ran ' oc get pods -n powerstore -o jsonpath="{.items[*].spec.containers[*].image}" | tr -s '[[:space:]]' '\n' | sort | uniq -c ' command to check the k8s images registry . Also, ran cert-csi for iSCSI and NFS protocols after successfully installing the driver.


- [x] Checked k8s images. Registry has been updated to registry.k8s.io
![k8s_images](https://user-images.githubusercontent.com/125348121/231975412-25fdc523-000e-441a-bcff-ca4a474b4db5.PNG)

- [x] Ran cert-csi.
![k8s_cert-csi](https://user-images.githubusercontent.com/125348121/231975620-b625c245-9ca6-4dc9-99e9-c2e852ffb687.PNG)
