### PR TITLE
Adding support for FQDN format support

### DIFF
--- a/helm/csi-powerstore/templates/node.yaml
+++ b/helm/csi-powerstore/templates/node.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2020-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2020-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/helm/csi-powerstore/templates/node.yaml
+++ b/helm/csi-powerstore/templates/node.yaml
@@ -105,7 +105,7 @@ spec:
       tolerations:
       {{- toYaml .Values.node.tolerations | nindent 6 }}
       {{ end }}
-      serviceAccount: {{ .Release.Name }}-node
+      serviceAccountName: {{ .Release.Name }}-node
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostIPC: true

--- a/pkg/array/array.go
+++ b/pkg/array/array.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/array/array.go
+++ b/pkg/array/array.go
@@ -234,9 +234,7 @@ func GetPowerStoreArrays(fs fs.Interface, filePath string) (map[string]*PowerSto
 			if len(sub) > 2 {
 				ip = sub[2]
 				if regexp.MustCompile(`^[0-9.]*$`).MatchString(sub[2]) {
-					if net.ParseIP(sub[2]) == nil {
 						return nil, nil, nil, fmt.Errorf("can't get ips from endpoint: %s", array.Endpoint)
-					}
 				}
 			} else {
 				return nil, nil, nil, fmt.Errorf("can't get ips from endpoint: %s", array.Endpoint)

--- a/pkg/array/array.go
+++ b/pkg/array/array.go
@@ -23,8 +23,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -224,15 +226,26 @@ func GetPowerStoreArrays(fs fs.Interface, filePath string) (map[string]*PowerSto
 			array.BlockProtocol = common.AutoDetectTransport
 		}
 		array.BlockProtocol = common.TransportType(strings.ToUpper(string(array.BlockProtocol)))
-
+		var ip string
 		ips := common.GetIPListFromString(array.Endpoint)
 		if ips == nil {
-			return nil, nil, nil, fmt.Errorf("can't get ips from endpoint: %s", array.Endpoint)
+			log.Warnf("didn't found an IP from the provided endPoint, it could be a FQDN. Please make sure to enter a valid FQDN in https://abc.com/api/rest format")
+			sub := strings.Split(array.Endpoint, "/")
+			if len(sub) > 2 {
+				ip = sub[2]
+				if regexp.MustCompile(`^[0-9.]*$`).MatchString(sub[2]) {
+					if net.ParseIP(sub[2]) == nil {
+						return nil, nil, nil, fmt.Errorf("can't get ips from endpoint: %s", array.Endpoint)
+					}
+				}
+			} else {
+				return nil, nil, nil, fmt.Errorf("can't get ips from endpoint: %s", array.Endpoint)
+			}
+		} else {
+			ip = ips[0]
 		}
-
-		ip := ips[0]
 		array.IP = ip
-		log.Infof("%s,%s,%s,%s,%t,%t,%s", array.Endpoint, array.GlobalID, array.Username, array.NasName, array.Insecure, array.IsDefault, array.BlockProtocol)
+		log.Infof("%s,%s,%s,%s,%t,%t,%s,%s", array.Endpoint, array.GlobalID, array.Username, array.NasName, array.Insecure, array.IsDefault, array.BlockProtocol, ip)
 		arrayMap[array.GlobalID] = array
 		mapper[ip] = array.GlobalID
 		if array.IsDefault && !foundDefault {

--- a/pkg/array/array.go
+++ b/pkg/array/array.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"path/filepath"
 	"regexp"
@@ -234,7 +233,7 @@ func GetPowerStoreArrays(fs fs.Interface, filePath string) (map[string]*PowerSto
 			if len(sub) > 2 {
 				ip = sub[2]
 				if regexp.MustCompile(`^[0-9.]*$`).MatchString(sub[2]) {
-						return nil, nil, nil, fmt.Errorf("can't get ips from endpoint: %s", array.Endpoint)
+					return nil, nil, nil, fmt.Errorf("can't get ips from endpoint: %s", array.Endpoint)
 				}
 			} else {
 				return nil, nil, nil, fmt.Errorf("can't get ips from endpoint: %s", array.Endpoint)

--- a/pkg/array/array_test.go
+++ b/pkg/array/array_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/array/array_test.go
+++ b/pkg/array/array_test.go
@@ -140,6 +140,13 @@ func TestGetPowerStoreArrays(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "can't get ips from endpoint")
 	})
+
+	t.Run("invalid endpoint", func(t *testing.T) {
+		f := &fs.Fs{Util: &gofsutil.FS{}}
+		_, _, _, err := array.GetPowerStoreArrays(f, "./testdata/invalid-endpoint.yaml")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "can't get ips from endpoint")
+	})
 	t.Run("no global ID", func(t *testing.T) {
 		f := &fs.Fs{Util: &gofsutil.FS{}}
 		_, _, _, err := array.GetPowerStoreArrays(f, "./testdata/no-globalID.yaml")

--- a/pkg/array/testdata/invalid-endpoint.yaml
+++ b/pkg/array/testdata/invalid-endpoint.yaml
@@ -1,0 +1,24 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+arrays:
+  - endpoint: "aaaaaaaaaaaaaa"
+    username: "admin"
+    globalID: "gid1"
+    password: "password"
+    skipCertificateValidation: true
+    blockProtocol: "auto"
+    isDefault: true

--- a/samples/secret/secret.yaml
+++ b/samples/secret/secret.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/secret/secret.yaml
+++ b/samples/secret/secret.yaml
@@ -20,7 +20,7 @@
 #
 arrays:
     # endpoint: full URL path to the PowerStore API
-    # Allowed Values: https://*.*.*.*/api/rest
+    # Allowed Values: https://*.*.*.*/api/rest or https://abc.com/api/rest
     # Default Value: None
   - endpoint: "https://10.0.0.1/api/rest"
 


### PR DESCRIPTION
# Description
Adding support for FQDN format support in endPoint for PowerStore Array.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/731|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Install the driver by providing endpoint in fqdn format (ex: https://abc.com/api/rest) and set topology key as csi-powerstore.dellemc.com/abc.com-PROTOCOL in SC.
![image](https://user-images.githubusercontent.com/109620911/232680120-aaa7ffa6-5ef9-4d63-8fb3-6a375e40dd85.png)
- [x] Ran cert-csi for NVMeTCP, iSCSI and NFS protocol and it ran successfully.
![image](https://user-images.githubusercontent.com/109620911/232679328-8ddbf1f3-03bf-4280-9605-dc850d158d35.png)
![image](https://user-images.githubusercontent.com/109620911/232679386-6f539f13-1954-419e-97ef-8ddde69d4143.png)
- [x] Ran UT and all passed successfully.
![image](https://user-images.githubusercontent.com/109620911/232679685-6b25b252-aba6-4c99-94c9-74f80b12669d.png)


