### PR TITLE
File Replication - RG Creation

### DIFF
--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -126,10 +126,62 @@ func (s *Service) CreateStorageProtectionGroup(ctx context.Context,
 	}
 
 	if protocol == "nfs" { // NFS protocol indicates a FileSystem on the storage array and requires different handling from block Volumes.
-		return nil, status.Error(codes.InvalidArgument, "replication is not supported for NFS volumes")
+		// get the NAS server from the filesystem
+		fs, err := arr.GetClient().GetFS(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		nasId := fs.NasServerID
+		log.Infof("!!!!!!!!!")
+		log.Infof("NAS ID: " + nasId)
+		nas, err := arr.GetClient().GetNAS(ctx, nasId)
+		if err != nil {
+			return nil, err
+		}
+		log.Infof("NAS name: " + nas.Name)
 
-		// TODO: Implement nfs replication.
+		// get the local and remote systems
+		rs, err := arr.Client.GetReplicationSessionByLocalResourceID(ctx, nasId)
+		if err != nil {
+			return nil, err
+		}
+		log.Infof("Replication session: " + rs.ID) // crashing here -- rs is null
 
+		localSystem, err := arr.Client.GetCluster(ctx)
+		if err != nil {
+			return nil, err
+		}
+		remoteSystem, err := arr.Client.GetRemoteSystem(ctx, rs.RemoteSystemId)
+		if err != nil {
+			return nil, err
+		}
+		log.Infof("Local system: " + localSystem.Name)
+		log.Infof("Remote system: " + remoteSystem.Name)
+
+		// define params
+		localParams := map[string]string{
+			s.replicationContextPrefix + "systemName":              localSystem.Name,
+			s.replicationContextPrefix + "managementAddress":       localSystem.ManagementAddress,
+			s.replicationContextPrefix + "remoteSystemName":        remoteSystem.Name,
+			s.replicationContextPrefix + "remoteManagementAddress": remoteSystem.ManagementAddress,
+			s.replicationContextPrefix + "globalID":                arrayID,
+			s.replicationContextPrefix + "remoteGlobalID":          remoteSystem.SerialNumber,
+			s.replicationContextPrefix + "nasName":                 nas.Name,
+		}
+		remoteParams := map[string]string{
+			s.replicationContextPrefix + "systemName":              remoteSystem.Name,
+			s.replicationContextPrefix + "managementAddress":       remoteSystem.ManagementAddress,
+			s.replicationContextPrefix + "remoteSystemName":        localSystem.Name,
+			s.replicationContextPrefix + "remoteManagementAddress": localSystem.ManagementAddress,
+			s.replicationContextPrefix + "globalID":                remoteSystem.SerialNumber,
+			s.replicationContextPrefix + "nasName":                 nas.Name,
+		}
+		return &csiext.CreateStorageProtectionGroupResponse{
+			LocalProtectionGroupId:          rs.LocalResourceId,
+			RemoteProtectionGroupId:         rs.RemoteResourceId,
+			LocalProtectionGroupAttributes:  localParams,
+			RemoteProtectionGroupAttributes: remoteParams,
+		}, nil
 	}
 
 	// Non-NFS protocol indicates a Volume on the storage array.

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -145,7 +145,7 @@ func (s *Service) CreateStorageProtectionGroup(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		log.Infof("Replication session: " + rs.ID) // crashing here -- rs is null
+		log.Infof("Replication session: " + rs.ID)
 
 		localSystem, err := arr.Client.GetCluster(ctx)
 		if err != nil {
@@ -662,6 +662,7 @@ func (s *Service) GetStorageProtectionGroupStatus(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	// TODO: If NFS type RGs require editing for getting their state, it'll be in this method.
 
 	var state csiext.StorageProtectionGroupStatus_State
 	switch rs.State {

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -132,20 +132,16 @@ func (s *Service) CreateStorageProtectionGroup(ctx context.Context,
 			return nil, err
 		}
 		nasId := fs.NasServerID
-		log.Infof("!!!!!!!!!")
-		log.Infof("NAS ID: " + nasId)
 		nas, err := arr.GetClient().GetNAS(ctx, nasId)
 		if err != nil {
 			return nil, err
 		}
-		log.Infof("NAS name: " + nas.Name)
 
 		// get the local and remote systems
 		rs, err := arr.Client.GetReplicationSessionByLocalResourceID(ctx, nasId)
 		if err != nil {
 			return nil, err
 		}
-		log.Infof("Replication session: " + rs.ID)
 
 		localSystem, err := arr.Client.GetCluster(ctx)
 		if err != nil {
@@ -155,8 +151,6 @@ func (s *Service) CreateStorageProtectionGroup(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		log.Infof("Local system: " + localSystem.Name)
-		log.Infof("Remote system: " + remoteSystem.Name)
 
 		// define params
 		localParams := map[string]string{


### PR DESCRIPTION
# Description
This PR covers the work required to create RGs on both source and target Kubernetes clusters for PowerStore file replication. 

These RGs are not currently in a usable, working state, but they do contain appropriate NAS information and are seen by the replication controller/replicator sidecar. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| [639](https://github.com/dell/csm/issues/639) |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

RGs were created manually via dynamic-provisioning of a PVC with a replication storage class. 
