### PR TITLE
Fix nvme label not added to csinode if session already exist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.1-0.20230825035253-f415b11a8bb6
 	github.com/dell/goiscsi v1.7.1-0.20230825043321-ba885cf11d2c
-	github.com/dell/gonvme v1.4.1-0.20230825045625-c9052dc2daf5
+	github.com/dell/gonvme v1.4.1-0.20230830093714-8a95173644bf
 	github.com/dell/gopowerstore v1.12.1-0.20230825043639-febcb83c748c
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/go-openapi/strfmt v0.21.3

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/dell/gofsutil v1.12.1-0.20230825035253-f415b11a8bb6 h1:VxIlpwiAf+ijsq
 github.com/dell/gofsutil v1.12.1-0.20230825035253-f415b11a8bb6/go.mod h1:mGMN5grVDtHv2imNw5+gFr2RmCqeyYgBFBldUbHtV78=
 github.com/dell/goiscsi v1.7.1-0.20230825043321-ba885cf11d2c h1:Dbtr1ieK8GPtJLNyXjOGG5rdKmYd3rw9kXyWLcK8GdM=
 github.com/dell/goiscsi v1.7.1-0.20230825043321-ba885cf11d2c/go.mod h1:PTlQGJaGKYgia95mGwwHSBgvfOr3BfLIjGNh1HT6p+s=
-github.com/dell/gonvme v1.4.1-0.20230825045625-c9052dc2daf5 h1:7j6cUQzJLgudjMz78R8oFeVrNJaq6FKu6+tpu6ainIg=
-github.com/dell/gonvme v1.4.1-0.20230825045625-c9052dc2daf5/go.mod h1:7MFbd7lWSaQwR5pf9ZnVZqhkAKkveSwQEO67jDBZuX0=
+github.com/dell/gonvme v1.4.1-0.20230830093714-8a95173644bf h1:guAd9LnmGnNcmNVgg0A2LFvkiQe33nOYcH2Cn5l21Dg=
+github.com/dell/gonvme v1.4.1-0.20230830093714-8a95173644bf/go.mod h1:7MFbd7lWSaQwR5pf9ZnVZqhkAKkveSwQEO67jDBZuX0=
 github.com/dell/gopowerstore v1.12.1-0.20230825043639-febcb83c748c h1:9MVGlDoCfMRXUp9Sk7JDY3vxWeAcDqY1y64J1HexkPg=
 github.com/dell/gopowerstore v1.12.1-0.20230825043639-febcb83c748c/go.mod h1:MJLVe9FLxhb/dXv8RuKtHwqGAAmRuAIMFqNOTK3ZMz0=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=


### PR DESCRIPTION
# Description
Fix nvme label not added to csinode if session already exist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/885 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed driver on SLES 15SP4 where nvme connections were already present.
![image](https://github.com/dell/csi-powerstore/assets/109056238/2343102c-c399-4c13-b076-f54d63a0690b)

