### PR TITLE
Fix for make gosec command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,4 +91,10 @@ coverage:
 	cd ./pkg; go tool cover -html=coverage.out -o coverage.html
 
 gosec:
-	gosec -quiet -log gosec.log -out=gosecresults.csv -fmt=csv ./...
+ifeq (, $(shell which gosec))
+	go install github.com/securego/gosec/v2/cmd/gosec@latest
+	$(shell $(GOBIN)/gosec -quiet -log gosec.log -out=gosecresults.csv -fmt=csv ./...)
+else
+	$(shell gosec -quiet -log gosec.log -out=gosecresults.csv -fmt=csv ./...)
+endif
+	@echo "Logs are stored at gosec.log, Outputfile at gosecresults.csv"


### PR DESCRIPTION
# Description
Fixing make gosec command.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1053 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran make gosec and generated csi-powerstore build
![image](https://github.com/dell/csi-powerstore/assets/109594002/f88f5a9d-4b48-4cc6-aeac-b40544699fc0)

