### PR TITLE
go version bump-up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/csi-powerstore/v2
 
-go 1.21
+go 1.22
 
 require (
 	github.com/akutz/gosync v0.1.0


### PR DESCRIPTION
Updating go version to latest available i.e. => 1.22