### PR TITLE
update OCP/K8s min/max support version to be consistent with documentation

### DIFF
--- a/dell-csi-helm-installer/verify-csi-powerstore.sh
+++ b/dell-csi-helm-installer/verify-csi-powerstore.sh
@@ -10,8 +10,8 @@
 
 # verify-csi-powerstore method
 function verify-csi-powerstore() {
-  verify_k8s_versions "1.24" "1.28"
-  verify_openshift_versions "4.12" "4.13"
+  verify_k8s_versions "1.24" "1.29"
+  verify_openshift_versions "4.13" "4.14"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-config"
   verify_alpha_snap_resources


### PR DESCRIPTION
# Description
OCP min/max version and k8s max version support does not match documentation: https://dell.github.io/csm-docs/docs/prerequisites/
Updating the verify script to include supported version

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1203 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
