### PR TITLE
Return FailedPrecondition if the volume has associated snapshot

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -499,15 +499,14 @@ func (s *Service) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest
 		}
 		// TODO: if len(vgs.VolumeGroup == 1) && it is the last volume : delete volume group
 		// TODO: What to do with RPO snaps?
-		// listSnaps, err := arr.GetClient().GetSnapshotsByVolumeID(ctx, id)
-		// if err != nil {
-		// 	return nil, status.Errorf(codes.Unknown, "failure getting snapshot: %s", err.Error())
-		// }
-		// if len(listSnaps) > 0 {
-		// 	return nil, status.Errorf(codes.FailedPrecondition,
-		// 		"unable to delete volume -- snapshots based on this volume still exist: %v",
-		// 		listSnaps)
-		// }
+		listSnaps, err := arr.GetClient().GetSnapshotsByVolumeID(ctx, id)
+		if err != nil {
+			return nil, status.Errorf(codes.Unknown, "failure getting snapshot: %s", err.Error())
+		}
+		if len(listSnaps) > 0 {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"unable to delete volume -- %d snapshots based on this volume still exist.", len(listSnaps))
+		}
 
 		_, err = arr.GetClient().DeleteVolume(ctx, nil, id)
 		if err == nil {


### PR DESCRIPTION
# Description
- Stops deletion of volumes if it has associated snapshots.
- Return FailedPrecondition if the volume has associated snapshots.
- Solves the issue of using snapshots when the source PVC has been deleted.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1338|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Cluster Test
- [x] Unit Test
- ![image](https://github.com/dell/csi-powerstore/assets/92086230/590e79f4-6a7d-464a-a803-91e4f09ebb74)

