### PR TITLE
Add new replication parameter 'mode' to storage class

### DIFF
--- a/pkg/controller/base.go
+++ b/pkg/controller/base.go
@@ -42,6 +42,8 @@ const (
 	VolumeSizeMultiple = 8192
 	// MaxVolumeNameLength max length for the volume name
 	MaxVolumeNameLength = 128
+	// ReplicationPrefix represents replication prefix
+	ReplicationPrefix = "replication.storage.dell.com"
 	// ErrUnknownAccessType represents error message for unknown access type
 	ErrUnknownAccessType = "unknown access type is not Block or Mount"
 	// ErrUnknownAccessMode represents error message for unknown access mode

--- a/pkg/controller/base.go
+++ b/pkg/controller/base.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,8 @@ const (
 	KeyFsTypeOld = "FsType"
 	// KeyReplicationEnabled represents key for replication enabled
 	KeyReplicationEnabled = "isReplicationEnabled"
+	// KeyReplicationMode represents key for replication mode
+	KeyReplicationMode = "mode"
 	// KeyReplicationRPO represents key for replication RPO
 	KeyReplicationRPO = "rpo"
 	// KeyReplicationRemoteSystem represents key for replication remote system

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -249,84 +249,105 @@ func (s *Service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 
 	// Check if replication is enabled
 	replicationEnabled := params[s.WithRP(KeyReplicationEnabled)]
+	isMetroVolume := false
 
 	if replicationEnabled == "true" && !useNFS {
 		log.Info("Preparing volume replication")
 
-		vgPrefix, ok := params[s.WithRP(KeyReplicationVGPrefix)]
-		if !ok {
-			return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no volume group prefix specified in storage class")
-		}
-		rpo, ok := params[s.WithRP(KeyReplicationRPO)]
-		if !ok {
-			return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no RPO specified in storage class")
-		}
-		rpoEnum := gopowerstore.RPOEnum(rpo)
-		if err := rpoEnum.IsValid(); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid rpo value")
-		}
 		remoteSystemName, ok := params[s.WithRP(KeyReplicationRemoteSystem)]
 		if !ok {
 			return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no remote system specified in storage class")
 		}
+		repMode := params[s.WithRP(KeyReplicationMode)]
+		if repMode == "" {
+			repMode = "ASYNC"
+		}
+		repMode = strings.ToUpper(repMode)
 
-		namespace := ""
-		if ignoreNS, ok := params[s.WithRP(KeyReplicationIgnoreNamespaces)]; ok && ignoreNS == "false" {
-			pvcNS, ok := params[KeyCSIPVCNamespace]
-			if ok {
-				namespace = pvcNS + "-"
+		switch repMode {
+		case "SYNC", "ASYNC":
+			// handle Sync and Async modes
+			vgPrefix, ok := params[s.WithRP(KeyReplicationVGPrefix)]
+			if !ok {
+				return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no volume group prefix specified in storage class")
 			}
-		}
+			rpo, ok := params[s.WithRP(KeyReplicationRPO)]
+			if !ok {
+				return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no RPO specified in storage class")
+			}
+			rpoEnum := gopowerstore.RPOEnum(rpo)
+			if err := rpoEnum.IsValid(); err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid RPO value")
+			}
 
-		vgName := vgPrefix + "-" + namespace + remoteSystemName + "-" + rpo
-		if len(vgName) > 128 {
-			vgName = vgName[:128]
-		}
-
-		vg, err = arr.Client.GetVolumeGroupByName(ctx, vgName)
-		if err != nil {
-			if apiError, ok := err.(gopowerstore.APIError); ok && apiError.NotFound() {
-				log.Infof("Volume group with name %s not found, creating it", vgName)
-
-				// ensure protection policy exists
-				pp, err := EnsureProtectionPolicyExists(ctx, arr, vgName, remoteSystemName, rpoEnum)
-				if err != nil {
-					return nil, status.Errorf(codes.Internal, "can't ensure protection policy exists %s", err.Error())
+			namespace := ""
+			if ignoreNS, ok := params[s.WithRP(KeyReplicationIgnoreNamespaces)]; ok && ignoreNS == "false" {
+				pvcNS, ok := params[KeyCSIPVCNamespace]
+				if ok {
+					namespace = pvcNS + "-"
 				}
+			}
 
-				group, err := arr.Client.CreateVolumeGroup(ctx, &gopowerstore.VolumeGroupCreate{
-					Name:               vgName,
-					ProtectionPolicyID: pp,
-				})
-				if err != nil {
-					return nil, status.Errorf(codes.Internal, "can't create volume group: %s", err.Error())
+			vgName := vgPrefix + "-" + namespace + remoteSystemName + "-" + rpo
+			if len(vgName) > 128 {
+				vgName = vgName[:128]
+			}
+
+			vg, err = arr.Client.GetVolumeGroupByName(ctx, vgName)
+			if err != nil {
+				if apiError, ok := err.(gopowerstore.APIError); ok && apiError.NotFound() {
+					log.Infof("Volume group with name %s not found, creating it", vgName)
+
+					// ensure protection policy exists
+					pp, err := EnsureProtectionPolicyExists(ctx, arr, vgName, remoteSystemName, rpoEnum)
+					if err != nil {
+						return nil, status.Errorf(codes.Internal, "can't ensure protection policy exists %s", err.Error())
+					}
+
+					group, err := arr.Client.CreateVolumeGroup(ctx, &gopowerstore.VolumeGroupCreate{
+						Name:               vgName,
+						ProtectionPolicyID: pp,
+					})
+					if err != nil {
+						return nil, status.Errorf(codes.Internal, "can't create volume group: %s", err.Error())
+					}
+
+					vg, err = arr.Client.GetVolumeGroup(ctx, group.ID)
+					if err != nil {
+						return nil, status.Errorf(codes.Internal, "can't query volume group by id %s : %s", group.ID, err.Error())
+					}
+
+				} else {
+					return nil, status.Errorf(codes.Internal, "can't query volume group by name %s : %s", vgName, err.Error())
 				}
-
-				vg, err = arr.Client.GetVolumeGroup(ctx, group.ID)
-				if err != nil {
-					return nil, status.Errorf(codes.Internal, "can't query volume group by id %s : %s", group.ID, err.Error())
-				}
-
 			} else {
-				return nil, status.Errorf(codes.Internal, "can't query volume group by name %s : %s", vgName, err.Error())
-			}
-		} else {
-			// group exists, check that protection policy applied
-			if vg.ProtectionPolicyID == "" {
-				pp, err := EnsureProtectionPolicyExists(ctx, arr, vgName, remoteSystemName, rpoEnum)
-				if err != nil {
-					return nil, status.Errorf(codes.Internal, "can't ensure protection policy exists %s", err.Error())
-				}
-				policyUpdate := gopowerstore.VolumeGroupChangePolicy{ProtectionPolicyID: pp}
-				_, err = arr.Client.UpdateVolumeGroupProtectionPolicy(ctx, vg.ID, &policyUpdate)
-				if err != nil {
-					return nil, status.Errorf(codes.Internal, "can't update volume group policy %s", err.Error())
+				// group exists, check that protection policy applied
+				if vg.ProtectionPolicyID == "" {
+					pp, err := EnsureProtectionPolicyExists(ctx, arr, vgName, remoteSystemName, rpoEnum)
+					if err != nil {
+						return nil, status.Errorf(codes.Internal, "can't ensure protection policy exists %s", err.Error())
+					}
+					policyUpdate := gopowerstore.VolumeGroupChangePolicy{ProtectionPolicyID: pp}
+					_, err = arr.Client.UpdateVolumeGroupProtectionPolicy(ctx, vg.ID, &policyUpdate)
+					if err != nil {
+						return nil, status.Errorf(codes.Internal, "can't update volume group policy %s", err.Error())
+					}
 				}
 			}
-		}
 
-		if c, ok := creator.(*SCSICreator); ok {
-			c.vg = &vg
+			if c, ok := creator.(*SCSICreator); ok {
+				c.vg = &vg
+			}
+		case "METRO":
+			// handle Metro mode
+			// TODO Verify VolumeGroup exists, if not create one
+			// There shouldn't be any protection policy on it with replication rule
+			// Configure Metro on VG (Check if it can be done on empty group). Otherwise configure after volume is added
+			// Optimize the above sync/async block as needed
+
+			isMetroVolume = true // set to true if volume group metro is not requested
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "replication enabled but invalid replication mode specified in storage class")
 		}
 	}
 
@@ -345,6 +366,10 @@ func (s *Service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		}
 	} else {
 		volumeResponse = getCSIVolume(resp.ID, sizeInBytes)
+	}
+
+	if isMetroVolume {
+		// TODO configure Metro on volume
 	}
 
 	// Fetch the service tag

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -436,7 +436,7 @@ var _ = ginkgo.Describe("CSIControllerService", func() {
 			res, err := ctrlSvc.CreateVolume(context.Background(), req)
 			gomega.Expect(res).To(gomega.BeNil())
 			gomega.Expect(err).NotTo(gomega.BeNil())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("invalid rpo value"))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("invalid RPO value"))
 		})
 
 		ginkgo.It("should fail when rpo not declared in parameters", func() {
@@ -455,6 +455,17 @@ var _ = ginkgo.Describe("CSIControllerService", func() {
 			gomega.Expect(res).To(gomega.BeNil())
 			gomega.Expect(err).NotTo(gomega.BeNil())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("replication enabled but no remote system specified in storage class"))
+		})
+
+		ginkgo.It("should fail when mode is incorrect", func() {
+			clientMock.On("CreateVolume", mock.Anything, mock.Anything).Return(gopowerstore.CreateResponse{ID: validBaseVolID}, nil)
+
+			req.Parameters[ctrlSvc.WithRP(controller.KeyReplicationMode)] = "SYNCMETRO"
+
+			res, err := ctrlSvc.CreateVolume(context.Background(), req)
+			gomega.Expect(res).To(gomega.BeNil())
+			gomega.Expect(err).NotTo(gomega.BeNil())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("invalid replication mode"))
 		})
 
 		ginkgo.It("should fail when volume group prefix not declared in parameters", func() {

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -635,7 +635,12 @@ func (s *Service) GetStorageProtectionGroupStatus(ctx context.Context,
 
 // WithRP appends Replication Prefix to provided string
 func (s *Service) WithRP(key string) string {
-	return s.replicationPrefix + "/" + key
+	replicationPrefix := s.replicationPrefix
+	if replicationPrefix == "" {
+		replicationPrefix = ReplicationPrefix
+	}
+
+	return replicationPrefix + "/" + key
 }
 
 func getRemoteCSIVolume(volumeID string, size int64) *csiext.Volume {

--- a/samples/storageclass/powerstore-replication.yaml
+++ b/samples/storageclass/powerstore-replication.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2021-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,11 +27,19 @@ parameters:
 
   # replication.storage.dell.com/isReplicationEnabled: 
   # Allowed values:
-  #   true: enable replication sidecar
-  #   false: disable replication sidecar 
+  #   true: replication is enabled
+  #   false: replication is disabled 
   # Optional: true
   # Default value: false
   replication.storage.dell.com/isReplicationEnabled: "true"
+
+  # replication.storage.dell.com/mode: replication mode
+  # Allowed values:
+  #   "ASYNC" - Asynchronous mode
+  #   "METRO" - Metro mode
+  # Optional: true
+  # Default value: "ASYNC"
+  replication.storage.dell.com/mode: "ASYNC"
 
   # replication.storage.dell.com/remoteStorageClassName: 
   # Allowed values: string
@@ -76,6 +84,7 @@ parameters:
   # Optional: false
   # Default value: None
   arrayID: "Unique"
+
   # FsType: file system type for mounted volumes
   # Allowed values:
   #   ext3: ext3 filesystem type


### PR DESCRIPTION
# Description
Added new replication parameter 'mode' to storage class. The replication mode values can be sync/async/metro.
Default is 'Async' to support backwards compatibility.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1443 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (More tests will be added when create metro volume is implemented)
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Performed volume creations with just the driver and made sure that the new code works as expected and backward compatibility is not broken.
PV without any replication parameters created successfully.

Driver log:
#### when invalid mode is specified in the Storage Class
Warning  ProvisioningFailed    14s (x7 over 77s)  csi-powerstore.dellemc.com_powerstore-controller-567bc8ff4c-8qxmf_3b81a379-e9ec-4831-b6c0-370f1ae08627  failed to provision volume with StorageClass "powerstore-replication-invalid": rpc error: code = InvalidArgument desc = replication enabled but invalid replication mode specified in storage class
  
#### when Metro mode is specified in the Storage Class
{"level":"info","msg":"Preparing volume replication","time":"2024-09-03T16:33:42.866888418Z"}
{"level":"info","msg":"Metro replication mode requested","time":"2024-09-03T16:33:42.866908807Z"}

#### when no mode or Async is specified in the Storage Class
{"level":"info","msg":"Preparing volume replication","time":"2024-09-03T16:43:02.25396221Z"}
{"level":"info","msg":"ASYNC replication mode requested","time":"2024-09-03T16:43:02.253974847Z"}
