### PR TITLE
Modify host name with updated prefix

### DIFF
--- a/pkg/array/array.go
+++ b/pkg/array/array.go
@@ -201,6 +201,8 @@ func GetPowerStoreArrays(fs fs.Interface, filePath string) (map[string]*PowerSto
 			rateLimit, err := strconv.Atoi(throttlingRateLimit)
 			if err != nil {
 				log.Errorf("can't get throttling rate limit, using default")
+			} else if rateLimit < 0 {
+				log.Errorf("throttling rate limit is negative, using default")
 			} else {
 				clientOptions.SetRateLimit(uint64(rateLimit))
 			}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1670,4 +1670,3 @@ func (s *Service) fileExists(filename string) bool {
 	}
 	return false
 }
-

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -4137,4 +4137,3 @@ func getNodeVolumeExpandValidRequest(volid string, isBlock bool) *csi.NodeExpand
 	}
 	return &req
 }
-

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -484,6 +484,8 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 							}},
 							Name: "host-name",
 						}}, nil)
+					clientMock.On("ModifyHost", mock.Anything, mock.Anything, "host-id").
+						Return(gopowerstore.CreateResponse{ID: "host-id"}, nil)
 
 					err := nodeSvc.Init()
 					gomega.Expect(err).To(gomega.BeNil())
@@ -4135,3 +4137,4 @@ func getNodeVolumeExpandValidRequest(volid string, isBlock bool) *csi.NodeExpand
 	}
 	return &req
 }
+


### PR DESCRIPTION
# Description
This PR includes:

- Update the host name on the array when for the same uniquely identified host, we have different host name and node id. This will happen when the driver is reinstalled with a different prefix other than the one for which host entry was created earlier.
- Removed the redundant computation of node id : `s.nodeID = host.Name + "-" + ip.String()`
- golangci-lint fixes in `pkg/array/array.go`

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1458 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the driver with default prefix and reinstalled with a different prefix. The host name was getting updated on both the array and the cluster.
![image](https://github.com/user-attachments/assets/ef4a4cef-985c-4953-b3bb-c461a6310ded)

![image](https://github.com/user-attachments/assets/72c45e41-d8be-4aac-a212-e865b0bd7136)

- [x] Created a volume and a pod consuming it. Written some data into the pod and then reinstalled the driver with a different prefix. The volume was still attached on the array and there were no changes seen in the pod, pv status on the cluster. The data written was found when logged into the pod.

- [x] Similar test as above. This time made sure after pod deletion; next time the pod goes to another node. In this scenario also, the data was found when logged into the pod.

- [x] UT
![image](https://github.com/user-attachments/assets/8ac59257-a2f0-41de-ac2e-22ece8634aea)
