### PR TITLE
Remove CSI driver-initiated pause and resume on metro volumes

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1340,40 +1340,30 @@ func (s *Service) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReque
 	}, nil
 }
 
-func pauseMetroSession(ctx context.Context, metroSessionID string, arr *array.PowerStoreArray) (paused bool, err error) {
+func isPausedMetroSession(ctx context.Context, metroSessionID string, arr *array.PowerStoreArray) (paused bool, err error) {
 	metroSession, err := arr.Client.GetReplicationSessionByID(ctx, metroSessionID)
 	if err != nil {
 		return false, fmt.Errorf("could not get metro replication session %s", metroSessionID)
 	}
 
-	// confirm the session is in a state we can pause from.
-	if metroSession.State != gopowerstore.RsStateOk &&
-		metroSession.State != gopowerstore.RsStateSynchronizing &&
-		metroSession.State != gopowerstore.RsStatePaused &&
-		metroSession.State != gopowerstore.RsStateSystemPaused &&
-		metroSession.State != gopowerstore.RsStateFractured {
-		return false, fmt.Errorf("could not pause the metro replication session, %s, because the session is not in expected state to pause", metroSession.ID)
-	}
+	log.Debugf("checking if metro replication session, %s, is paused", metroSession.ID)
 
 	if metroSession.State != gopowerstore.RsStatePaused {
-		log.Debugf("pausing metro replication session, %s", metroSession.ID)
-
-		// pause the replication session
-		_, err := arr.Client.ExecuteActionOnReplicationSession(ctx, metroSession.ID, gopowerstore.RsActionPause, nil)
-		if err != nil {
-			return false, fmt.Errorf("metro replication session, %s, could not be paused: %s", metroSession.ID, err.Error())
-		}
-	} else {
-		log.Debugf("metro replication session, %s, already paused", metroSession.ID)
+		return false, errors.New("metro replication session not in 'paused' state")
 	}
+
+	log.Debugf("metro replication session, %s, is paused", metroSession.ID)
+
 	return true, nil
 }
 
-func resumeMetroSession(ctx context.Context, metroSessionID string, array *array.PowerStoreArray) (resumed bool, err error) {
+func isResumedMetroSession(ctx context.Context, metroSessionID string, array *array.PowerStoreArray) (resumed bool, err error) {
 	metroSession, err := array.Client.GetReplicationSessionByID(ctx, metroSessionID)
 	if err != nil {
 		return false, fmt.Errorf("could not get metro replication session: %s", err.Error())
 	}
+
+	log.Debugf("checking if metro replication session, %s, has been resumed", metroSession.ID)
 
 	// nothing to do if not paused
 	if metroSession.State == gopowerstore.RsStateOk ||
@@ -1381,22 +1371,11 @@ func resumeMetroSession(ctx context.Context, metroSessionID string, array *array
 		metroSession.State == gopowerstore.RsStateResuming ||
 		metroSession.State == gopowerstore.RsStateSwitchingToMetroSync ||
 		metroSession.State == gopowerstore.RsStateFractured {
-		log.Debugf("metro replication session, %s, already resumed", metroSession.ID)
-		return false, nil
+		log.Debugf("metro replication session, %s, has been resumed", metroSession.ID)
+		return true, nil
 	}
 
-	// metro session can only be resumed if it is in 'paused' state
-	if metroSession.State != gopowerstore.RsStatePaused {
-		return false, errors.New("the metro session must be in 'paused' state before resuming")
-	}
-
-	log.Debugf("resuming metro replication session %s", metroSession.ID)
-	_, err = array.Client.ExecuteActionOnReplicationSession(ctx, metroSession.ID, gopowerstore.RsActionResume, nil)
-	if err != nil {
-		return false, fmt.Errorf("metro replication session, %s, could not be resumed: %s", metroSession.ID, err.Error())
-	}
-
-	return true, nil
+	return false, errors.New("the metro replication session has not been resumed")
 }
 
 // ControllerExpandVolume resizes Volume or FileSystem by increasing available volume capacity in the storage array.
@@ -1433,10 +1412,11 @@ func (s *Service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 		if vol.Size < requiredBytes {
 			if isMetro {
 				// must pause metro session before modifying the volume
-				_, err = pauseMetroSession(ctx, vol.MetroReplicationSessionID, array)
+				_, err = isPausedMetroSession(ctx, vol.MetroReplicationSessionID, array)
 				if err != nil {
 					return nil, status.Errorf(codes.Internal,
-						"failed to expand the volume %s because the metro replication session could not be paused: %s", vol.Name, err.Error())
+						"failed to expand the volume, %s, because the metro replication session is not paused. please pause the metro replication session: %s",
+						vol.Name, err.Error())
 				}
 			}
 
@@ -1450,7 +1430,7 @@ func (s *Service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 		// check the metro session state and resume if necessary
 		// in case the previous request failed after expanding the volume, resume the session
 		if isMetro {
-			volExpanded, err = resumeMetroSession(ctx, vol.MetroReplicationSessionID, array)
+			volExpanded, err = isResumedMetroSession(ctx, vol.MetroReplicationSessionID, array)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal,
 					"failed to expand the volume %s because the metro replication session could not be resumed: %s", vol.Name, err.Error())

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2292,15 +2292,10 @@ var _ = ginkgo.Describe("CSIControllerService", func() {
 					mock.AnythingOfType("*gopowerstore.VolumeModify"),
 					validBaseVolID).
 					Return(gopowerstore.EmptyResponse(""), nil)
-				// Return okay to pause session
+				// Return metro session status as paused
 				clientMock.On("GetReplicationSessionByID", mock.Anything, validSessionID).Return(gopowerstore.ReplicationSession{
 					ID:    validSessionID,
 					State: gopowerstore.RsStatePaused,
-				}, nil).Times(1)
-				// Return paused to resume session
-				clientMock.On("GetReplicationSessionByID", mock.Anything, validSessionID).Return(gopowerstore.ReplicationSession{
-					ID:    validSessionID,
-					State: gopowerstore.RsStateOk,
 				}, nil).Times(1)
 
 				req := getTypicalControllerExpandRequest(validMetroBlockVolumeID, validVolSize*2)
@@ -2393,34 +2388,6 @@ var _ = ginkgo.Describe("CSIControllerService", func() {
 
 				gomega.Expect(err).ToNot(gomega.BeNil())
 				gomega.Expect(err.Error()).To(gomega.ContainSubstring("metro replication session not in 'paused' state"))
-			})
-
-			ginkgo.It("should fail if metro session is not resumed after volume expansion", func() {
-				clientMock.On("GetVolume", mock.Anything, validBaseVolID).Return(gopowerstore.Volume{
-					MetroReplicationSessionID: validSessionID,
-					Size:                      validVolSize,
-				}, nil)
-				clientMock.On("ModifyVolume",
-					mock.Anything,
-					mock.AnythingOfType("*gopowerstore.VolumeModify"),
-					validBaseVolID).
-					Return(gopowerstore.EmptyResponse(""), nil)
-				// Return okay to pause session
-				clientMock.On("GetReplicationSessionByID", mock.Anything, validSessionID).Return(gopowerstore.ReplicationSession{
-					ID:    validSessionID,
-					State: gopowerstore.RsStatePaused,
-				}, nil).Times(1)
-				// Return error state for resume failure
-				clientMock.On("GetReplicationSessionByID", mock.Anything, validSessionID).Return(gopowerstore.ReplicationSession{
-					ID:    validSessionID,
-					State: gopowerstore.RsStatePaused,
-				}, nil).Times(1)
-
-				req := getTypicalControllerExpandRequest(validMetroBlockVolumeID, validVolSize*2)
-				_, err := ctrlSvc.ControllerExpandVolume(context.Background(), req)
-
-				gomega.Expect(err).ToNot(gomega.BeNil())
-				gomega.Expect(err.Error()).To(gomega.ContainSubstring("the metro replication session has not been resumed"))
 			})
 		})
 


### PR DESCRIPTION
# Description
Removing CSI driver-initiated pause and resume actions for metro replication session during volume expansion operations.
User must now pause the metro session from the PowerStore UI before initiating a volume expansion request within Kubernetes and resume the metro session after the PVC reflects the updated size.

Removed unit tests that were no longer relevant to the implementation.
_coverage percentage has been maintained_

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1443 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# Testing
StorageClass for testing: 
![image](https://github.com/user-attachments/assets/f0c64ecc-acaf-4ecf-85c9-78f7bd972a72)

### Manual Volume Expansion
- Created and applied a metro storage class with `allowVolumeExpansion: true`.
- Created a pod with 8Gi PVC and waited for the PV to be provisioned.
- Paused the metro session for the volume from the PowerStore UI.
- Initiated the expand-volume request by editing the PVC from 8Gi to 20Gi, and noted the change reflected in the PV.
- Resumed the metro session for the volume from the PowerStore UI.
- After the metro session state returned to 'Operating Normally (Active-Active), noted the PVC also reflected the new volume size (about 3m from the time the resume operation occurred).
- Performed a write operation in the directory mounted via the PVC.

### Cert-csi 
#### PowerStore Metro
Performed cert-csi testing with below tests to confirm no regressions were introduced for PowerStore Metro Volumes.
![image](https://github.com/user-attachments/assets/68a833ca-3d3b-4466-af56-32b82ad8010a)
![image](https://github.com/user-attachments/assets/ef0a8e6f-0fad-400d-8c00-840f3fc108e9)

#### PowerStore Block ext4
Performed cert-csi testing with below tests to confirm no regressions were introduced for PowerStore ext4 block volumes.
![image](https://github.com/user-attachments/assets/e54240c0-80c5-4fb1-bdca-5dc12b2d3ec8)
![image](https://github.com/user-attachments/assets/5c666609-ded3-4e43-b177-45aaf7b1cc2f)
![image](https://github.com/user-attachments/assets/1ba3bde1-1165-4e6b-8046-c5c659453f11)
