### PR TITLE
Fix incorrect storage protocol usage when multiple appliances are defined in secret

### DIFF
--- a/pkg/node/node_connectivity_checker.go
+++ b/pkg/node/node_connectivity_checker.go
@@ -228,7 +228,7 @@ func (s *Service) nodeProbe(_ context.Context, array *array.PowerStoreArray) err
 	log.Debugf("Successfully got Host on %s", array.GlobalID)
 	s.populateTargetsInCache(array)
 	// check if nvme sessions are active
-	if s.useNVME {
+	if s.useNVME[array.GlobalID] {
 		log.Debugf("Checking if nvme sessions are active on node or not")
 		sessions, _ := s.nvmeLib.GetSessions()
 		for _, target := range s.nvmeTargets[array.GlobalID] {
@@ -247,7 +247,7 @@ func (s *Service) nodeProbe(_ context.Context, array *array.PowerStoreArray) err
 			return nil
 		}
 		return fmt.Errorf("no active nvme sessions")
-	} else if s.useFC {
+	} else if s.useFC[array.GlobalID] {
 		log.Debugf("Checking if FC sessions are active on node or not")
 		for _, initiator := range host.Initiators {
 			if len(initiator.ActiveSessions) > 0 {
@@ -282,12 +282,12 @@ func (s *Service) nodeProbe(_ context.Context, array *array.PowerStoreArray) err
 func (s *Service) populateTargetsInCache(array *array.PowerStoreArray) {
 	// if nvmeTargets in cache is empty
 	// this could be empty in 2 cases: Either container is getting restarted or discovery & login has failed in NodeGetInfo
-	if s.useNVME {
+	if s.useNVME[array.GlobalID] {
 		if len(s.nvmeTargets[array.GlobalID]) != 0 {
 			return
 		}
 		// for NVMeFC
-		if s.useFC {
+		if s.useFC[array.GlobalID] {
 			nvmefcInfo, err := common.GetNVMEFCTargetInfoFromStorage(array.GetClient(), "")
 			if err != nil {
 				log.Errorf("couldn't get targets from the array: %s", err.Error())
@@ -328,7 +328,7 @@ func (s *Service) populateTargetsInCache(array *array.PowerStoreArray) {
 				break
 			}
 		}
-	} else if !s.useFC && !s.useNFS {
+	} else if !s.useFC[array.GlobalID] && !s.useNFS {
 		// if iscsiTargets in cache is empty
 		if len(s.iscsiTargets[array.GlobalID]) != 0 {
 			return

--- a/pkg/node/node_connectivity_checker.go
+++ b/pkg/node/node_connectivity_checker.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2022-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -88,6 +88,8 @@ const (
 		"staging/csi-44b46e98ae/c875b4f0-172e-4238-aec7-95b379eb55db"
 	firstValidIP       = "gid1"
 	secondValidIP      = "gid2"
+	firstGlobalID      = "unique1"
+	secondGlobalID     = "unique2"
 	validNasName       = "my-nas-name"
 	validNasID         = "e8f4c5f8-c2fc-4df4-bd99-c292c12b55be"
 	validNfsServerID   = "e8f4c5f8-c2fc-4dd2-bd99-c292c12b55be"
@@ -202,7 +204,7 @@ func getTestArrays() map[string]*array.PowerStoreArray {
 		BlockProtocol: common.ISCSITransport,
 		Insecure:      true,
 		IsDefault:     true,
-		GlobalID:      "unique",
+		GlobalID:      firstGlobalID,
 		Client:        clientMock,
 		IP:            firstValidIP,
 	}
@@ -213,7 +215,7 @@ func getTestArrays() map[string]*array.PowerStoreArray {
 		NasName:       validNasName,
 		BlockProtocol: common.NoneTransport,
 		Insecure:      true,
-		GlobalID:      "unique2",
+		GlobalID:      secondGlobalID,
 		Client:        clientMock,
 		IP:            secondValidIP,
 	}
@@ -549,7 +551,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 			ginkgo.It("should create FC host", func() {
 				nodeSvc.Arrays()[firstValidIP].BlockProtocol = common.FcTransport
 				nodeSvc.nodeID = ""
-				nodeSvc.useFC["unique"] = true
+				nodeSvc.useFC[firstGlobalID] = true
 				conn, _ := net.Dial("udp", "127.0.0.1:80")
 				fsMock.On("NetDial", mock.Anything).Return(
 					conn,
@@ -598,7 +600,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 			ginkgo.It("should create NVMe host", func() {
 				nodeSvc.Arrays()[firstValidIP].BlockProtocol = common.NVMEFCTransport
 				nodeSvc.nodeID = ""
-				nodeSvc.useNVME[firstValidIP] = true
+				nodeSvc.useNVME[firstGlobalID] = true
 				fsMock.On("ReadFile", mock.Anything).Return([]byte("my-host-id"), nil)
 				conn, _ := net.Dial("udp", "127.0.0.1:80")
 				fsMock.On("NetDial", mock.Anything).Return(
@@ -636,6 +638,94 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 				err := nodeSvc.Init()
 				gomega.Expect(err).To(gomega.BeNil())
+			})
+		})
+
+		ginkgo.When("protocol flag initialization", func() {
+			ginkgo.It("should have correct entry for each array - NVMeTCP and iSCSI", func() {
+				nodeSvc.Arrays()[firstValidIP].BlockProtocol = common.NVMETCPTransport
+				nodeSvc.Arrays()[secondValidIP].BlockProtocol = common.ISCSITransport
+				nodeSvc.nodeID = ""
+				fsMock.On("ReadFile", mock.Anything).Return([]byte("my-host-id"), nil)
+				conn, _ := net.Dial("udp", "127.0.0.1:80")
+				fsMock.On("NetDial", mock.Anything).Return(conn, nil)
+				iscsiConnectorMock.On("GetInitiatorName", mock.Anything).
+					Return(validISCSIInitiators, nil)
+				nvmeConnectorMock.On("GetInitiatorName", mock.Anything).
+					Return(validNVMEInitiators, nil)
+				fcConnectorMock.On("GetInitiatorPorts", mock.Anything).
+					Return(validFCTargetsWWPN, nil)
+
+				clientMock.On("GetHostByName", mock.Anything, mock.AnythingOfType("string")).
+					Return(gopowerstore.Host{}, gopowerstore.APIError{
+						ErrorMsg: &api.ErrorMsg{
+							StatusCode: http.StatusNotFound,
+						},
+					})
+				clientMock.On("GetHosts", mock.Anything).Return(
+					[]gopowerstore.Host{{
+						ID: "host-id",
+						Initiators: []gopowerstore.InitiatorInstance{{
+							PortName: "not-matching-port-name",
+							PortType: gopowerstore.InitiatorProtocolTypeEnumNVME,
+						}},
+						Name: "host-name",
+					}}, nil)
+				clientMock.On("GetCustomHTTPHeaders").Return(make(http.Header))
+				clientMock.On("GetSoftwareMajorMinorVersion", context.Background()).Return(float32(3.0), nil)
+				clientMock.On("SetCustomHTTPHeaders", mock.Anything).Return(nil)
+				clientMock.On("CreateHost", mock.Anything, mock.Anything).
+					Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+
+				err := nodeSvc.Init()
+				gomega.Expect(err).To(gomega.BeNil())
+				gomega.Expect(nodeSvc.useNVME[firstGlobalID]).To(gomega.BeTrue())
+				gomega.Expect(nodeSvc.useFC[firstGlobalID]).To(gomega.BeFalse())
+				gomega.Expect(nodeSvc.useNVME[secondGlobalID]).To(gomega.BeFalse())
+				gomega.Expect(nodeSvc.useFC[secondGlobalID]).To(gomega.BeFalse())
+			})
+
+			ginkgo.It("should have correct entry for each array - iSCSI and NVMeFC", func() {
+				nodeSvc.Arrays()[firstValidIP].BlockProtocol = common.ISCSITransport
+				nodeSvc.Arrays()[secondValidIP].BlockProtocol = common.NVMEFCTransport
+				nodeSvc.nodeID = ""
+				fsMock.On("ReadFile", mock.Anything).Return([]byte("my-host-id"), nil)
+				conn, _ := net.Dial("udp", "127.0.0.1:80")
+				fsMock.On("NetDial", mock.Anything).Return(conn, nil)
+				iscsiConnectorMock.On("GetInitiatorName", mock.Anything).
+					Return(validISCSIInitiators, nil)
+				nvmeConnectorMock.On("GetInitiatorName", mock.Anything).
+					Return(validNVMEInitiators, nil)
+				fcConnectorMock.On("GetInitiatorPorts", mock.Anything).
+					Return(validFCTargetsWWPN, nil)
+
+				clientMock.On("GetHostByName", mock.Anything, mock.AnythingOfType("string")).
+					Return(gopowerstore.Host{}, gopowerstore.APIError{
+						ErrorMsg: &api.ErrorMsg{
+							StatusCode: http.StatusNotFound,
+						},
+					})
+				clientMock.On("GetHosts", mock.Anything).Return(
+					[]gopowerstore.Host{{
+						ID: "host-id",
+						Initiators: []gopowerstore.InitiatorInstance{{
+							PortName: "not-matching-port-name",
+							PortType: gopowerstore.InitiatorProtocolTypeEnumNVME,
+						}},
+						Name: "host-name",
+					}}, nil)
+				clientMock.On("GetCustomHTTPHeaders").Return(make(http.Header))
+				clientMock.On("GetSoftwareMajorMinorVersion", context.Background()).Return(float32(3.0), nil)
+				clientMock.On("SetCustomHTTPHeaders", mock.Anything).Return(nil)
+				clientMock.On("CreateHost", mock.Anything, mock.Anything).
+					Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+
+				err := nodeSvc.Init()
+				gomega.Expect(err).To(gomega.BeNil())
+				gomega.Expect(nodeSvc.useNVME[firstGlobalID]).To(gomega.BeFalse())
+				gomega.Expect(nodeSvc.useFC[firstGlobalID]).To(gomega.BeFalse())
+				gomega.Expect(nodeSvc.useNVME[secondGlobalID]).To(gomega.BeTrue())
+				gomega.Expect(nodeSvc.useFC[secondGlobalID]).To(gomega.BeTrue())
 			})
 		})
 	})
@@ -715,7 +805,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 					}, nil)
 
 				arrays := getTestArrays()
-				nodeSvc.useNVME["unique"] = true
+				nodeSvc.useNVME[firstGlobalID] = true
 				clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).
 					Return([]gopowerstore.IPPoolAddress{}, nil)
 				clientMock.On("GetStorageNVMETCPTargetAddresses", mock.Anything).
@@ -726,7 +816,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 						NVMeNQN: validNVMEInitiators[0],
 					}, nil)
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
-				nodeSvc.useNVME["unique"] = false
+				nodeSvc.useNVME[firstGlobalID] = false
 				gomega.Expect(err.Error()).To(gomega.ContainSubstring("no active nvme sessions"))
 			})
 		})
@@ -788,11 +878,11 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 						NVMeNQN: validNVMEInitiators[0],
 					}, nil)
 				nodeSvc.useNFS = true
-				nodeSvc.useNVME["unique"] = true
+				nodeSvc.useNVME[firstGlobalID] = true
 				arrays := getTestArrays()
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
 				nodeSvc.useNFS = false
-				nodeSvc.useNVME["unique"] = false
+				nodeSvc.useNVME[firstGlobalID] = false
 				gomega.Expect(err).To(gomega.BeNil())
 			})
 		})
@@ -830,7 +920,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 					Return([]gopowerstore.IPPoolAddress{}, nil)
 				arrays := getTestArrays()
 				nodeSvc.useNFS = true
-				nodeSvc.iscsiTargets["unique"] = []string{"iqn.2015-10.com.dell:dellemc-foobar-123-a-7ceb34a0"}
+				nodeSvc.iscsiTargets[firstGlobalID] = []string{"iqn.2015-10.com.dell:dellemc-foobar-123-a-7ceb34a0"}
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
 
 				gomega.Expect(err).To(gomega.BeNil())
@@ -871,10 +961,10 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 					Return([]gopowerstore.IPPoolAddress{}, nil)
 				arrays := getTestArrays()
 				nodeSvc.useNFS = true
-				nodeSvc.useNVME["unique"] = true
-				nodeSvc.nvmeTargets["unique"] = []string{"nqn.1988-11.com.dell.mock:00:e6e2d5b871f1403E169D0"}
+				nodeSvc.useNVME[firstGlobalID] = true
+				nodeSvc.nvmeTargets[firstGlobalID] = []string{"nqn.1988-11.com.dell.mock:00:e6e2d5b871f1403E169D0"}
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
-				nodeSvc.useNVME["unique"] = false
+				nodeSvc.useNVME[firstGlobalID] = false
 				gomega.Expect(err).To(gomega.BeNil())
 				gomega.Expect(nodeSvc.useNFS).To(gomega.BeFalse())
 			})
@@ -928,7 +1018,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 					}, nil)
 
 				arrays := getTestArrays()
-				nodeSvc.iscsiTargets["unique"] = []string{"iqn.2015-10.com.dell:dellemc-foobar-123-a-7ceb34a0"}
+				nodeSvc.iscsiTargets[firstGlobalID] = []string{"iqn.2015-10.com.dell:dellemc-foobar-123-a-7ceb34a0"}
 				nodeSvc.startNodeToArrayConnectivityCheck(context.Background())
 
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
@@ -967,11 +1057,11 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 					}, nil)
 
 				arrays := getTestArrays()
-				if nodeSvc.useNVME["unique"] {
-					nodeSvc.useNVME["unique"] = false
+				if nodeSvc.useNVME[firstGlobalID] {
+					nodeSvc.useNVME[firstGlobalID] = false
 				}
-				if !nodeSvc.useFC["unique"] {
-					nodeSvc.useFC["unique"] = true
+				if !nodeSvc.useFC[firstGlobalID] {
+					nodeSvc.useFC[firstGlobalID] = true
 				}
 
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
@@ -991,15 +1081,15 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 					}, nil)
 
 				arrays := getTestArrays()
-				if nodeSvc.useNVME["unique"] {
-					nodeSvc.useNVME["unique"] = false
+				if nodeSvc.useNVME[firstGlobalID] {
+					nodeSvc.useNVME[firstGlobalID] = false
 				}
-				nodeSvc.useFC["unique"] = true
+				nodeSvc.useFC[firstGlobalID] = true
 
 				err := nodeSvc.nodeProbe(context.Background(), arrays["gid1"])
 				gomega.Expect(err).ToNot(gomega.BeNil())
-				if nodeSvc.useFC["unique"] {
-					nodeSvc.useFC["unique"] = false
+				if nodeSvc.useFC[firstGlobalID] {
+					nodeSvc.useFC[firstGlobalID] = false
 				}
 			})
 		})
@@ -1030,8 +1120,8 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 		ginkgo.When("using NVMeFC", func() {
 			ginkgo.It("should successfully stage NVMeFC volume", func() {
-				nodeSvc.useNVME["unique"] = true
-				nodeSvc.useFC["unique"] = true
+				nodeSvc.useNVME[firstGlobalID] = true
+				nodeSvc.useFC[firstGlobalID] = true
 				nvmeConnectorMock.On("ConnectVolume", mock.Anything, gobrick.NVMeVolumeInfo{
 					Targets: validNVMEFCTargetInfo,
 					WWN:     validDeviceWWN,
@@ -1052,7 +1142,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 		ginkgo.When("using FC", func() {
 			ginkgo.It("should successfully stage FC volume", func() {
-				nodeSvc.useFC["unique"] = true
+				nodeSvc.useFC[firstGlobalID] = true
 				fcConnectorMock.On("ConnectVolume", mock.Anything, gobrick.FCVolumeInfo{
 					Targets: validFCTargetsInfo,
 					Lun:     validLUNIDINT,
@@ -1410,8 +1500,8 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 			})
 
 			ginkgo.It("should fail [nvmefcTargets]", func() {
-				nodeSvc.useNVME["unique"] = true
-				nodeSvc.useFC["unique"] = true
+				nodeSvc.useNVME[firstGlobalID] = true
+				nodeSvc.useFC[firstGlobalID] = true
 				res, err := nodeSvc.NodeStageVolume(context.Background(), &csi.NodeStageVolumeRequest{
 					VolumeId: validBlockVolumeID,
 					PublishContext: map[string]string{
@@ -1428,7 +1518,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 			})
 
 			ginkgo.It("should fail [fcTargets]", func() {
-				nodeSvc.useFC["unique"] = true
+				nodeSvc.useFC[firstGlobalID] = true
 				res, err := nodeSvc.NodeStageVolume(context.Background(), &csi.NodeStageVolumeRequest{
 					VolumeId: validBlockVolumeID,
 					PublishContext: map[string]string{
@@ -1675,7 +1765,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 			})
 
 			ginkgo.It("should succeed [FC]", func() {
-				nodeSvc.useFC["unique"] = true
+				nodeSvc.useFC[firstGlobalID] = true
 				mountInfo := []gofsutil.Info{
 					{
 						Device: validDevName,
@@ -1706,7 +1796,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 			})
 
 			ginkgo.It("should succeed [NVMe]", func() {
-				nodeSvc.useNVME["unique"] = true
+				nodeSvc.useNVME[firstGlobalID] = true
 				mountInfo := []gofsutil.Info{
 					{
 						Device: validDevName,
@@ -3486,7 +3576,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 		ginkgo.When("using FC", func() {
 			ginkgo.It("should return FC topology segments", func() {
-				nodeSvc.useFC["unique"] = true
+				nodeSvc.useFC[firstGlobalID] = true
 				conn, _ := net.Dial("udp", "127.0.0.1:80")
 				fsMock.On("NetDial", mock.Anything).Return(
 					conn,
@@ -3536,7 +3626,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 			ginkgo.When("reusing host", func() {
 				ginkgo.It("should properly deal with additional IPs", func() {
-					nodeSvc.useFC["unique"] = true
+					nodeSvc.useFC[firstGlobalID] = true
 					nodeID := nodeSvc.nodeID
 					nodeSvc.nodeID = nodeID + "-" + "192.168.0.1"
 					nodeSvc.reusedHost = true
@@ -3589,7 +3679,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 				ginkgo.When("there is no ip in nodeID", func() {
 					ginkgo.It("should not return FC topology key", func() {
-						nodeSvc.useFC["unique"] = true
+						nodeSvc.useFC[firstGlobalID] = true
 						nodeID := nodeSvc.nodeID
 						nodeSvc.nodeID = "nodeid-with-no-ip"
 						nodeSvc.reusedHost = true
@@ -3643,7 +3733,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 			ginkgo.When("we can not get info about hosts from array", func() {
 				ginkgo.It("should not return FC topology key", func() {
-					nodeSvc.useFC["unique"] = true
+					nodeSvc.useFC[firstGlobalID] = true
 					e := "internal error"
 					clientMock.On("GetHostByName", mock.Anything, nodeSvc.nodeID).
 						Return(gopowerstore.Host{}, errors.New(e))
@@ -3671,7 +3761,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 			ginkgo.When("host initiators is empty", func() {
 				ginkgo.It("should not return FC topology key", func() {
-					nodeSvc.useFC["unique"] = true
+					nodeSvc.useFC[firstGlobalID] = true
 					clientMock.On("GetHostByName", mock.Anything, nodeSvc.nodeID).
 						Return(gopowerstore.Host{
 							ID:         "host-id",
@@ -3702,7 +3792,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 			ginkgo.When("there is no active sessions", func() {
 				ginkgo.It("should not return FC topology key", func() {
-					nodeSvc.useFC["unique"] = true
+					nodeSvc.useFC[firstGlobalID] = true
 					conn, _ := net.Dial("udp", "127.0.0.1:80")
 					fsMock.On("NetDial", mock.Anything).Return(
 						conn,
@@ -3743,8 +3833,8 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 		ginkgo.When("using NVMeFC", func() {
 			ginkgo.It("should return NVMeFC topology segments", func() {
-				nodeSvc.useNVME["unique"] = true
-				nodeSvc.useFC["unique"] = true
+				nodeSvc.useNVME[firstGlobalID] = true
+				nodeSvc.useFC[firstGlobalID] = true
 				clientMock.On("GetCluster", mock.Anything).
 					Return(gopowerstore.Cluster{
 						Name:    validClusterName,
@@ -3782,8 +3872,8 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 			ginkgo.When("NVMeFC targets cannot be discovered", func() {
 				ginkgo.It("should not return NVMeFC topology segments", func() {
-					nodeSvc.useNVME["unique"] = true
-					nodeSvc.useFC["unique"] = true
+					nodeSvc.useNVME[firstGlobalID] = true
+					nodeSvc.useFC[firstGlobalID] = true
 					clientMock.On("GetCluster", mock.Anything).
 						Return(gopowerstore.Cluster{
 							Name:    validClusterName,
@@ -3821,8 +3911,8 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 		ginkgo.When("using NVMeTCP", func() {
 			ginkgo.It("should return NVMeTCP topology segments", func() {
-				nodeSvc.useNVME["unique"] = true
-				nodeSvc.useFC["unique"] = false
+				nodeSvc.useNVME[firstGlobalID] = true
+				nodeSvc.useFC[firstGlobalID] = false
 				clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).Return([]gopowerstore.IPPoolAddress{
 					{
 						Address: "192.168.1.1",
@@ -3867,8 +3957,8 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 				ginkgo.It("should not return nvme topology key", func() {
 					goiscsi.GOISCSIMock.InduceDiscoveryError = true
 					gonvme.GONVMEMock.InduceDiscoveryError = true
-					nodeSvc.useNVME["unique"] = true
-					nodeSvc.useFC["unique"] = false
+					nodeSvc.useNVME[firstGlobalID] = true
+					nodeSvc.useFC[firstGlobalID] = false
 					clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).Return([]gopowerstore.IPPoolAddress{
 						{
 							Address: "192.168.1.1",
@@ -3912,8 +4002,8 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 			ginkgo.When("we cannot get NVMeTCP targets from the array", func() {
 				ginkgo.It("should not return NVMeTCP topology segments", func() {
-					nodeSvc.useNVME["unique"] = true
-					nodeSvc.useFC["unique"] = false
+					nodeSvc.useNVME[firstGlobalID] = true
+					nodeSvc.useFC[firstGlobalID] = false
 					e := "internalerror"
 					clientMock.On("GetStorageISCSITargetAddresses", mock.Anything).Return([]gopowerstore.IPPoolAddress{
 						{


### PR DESCRIPTION
# Description
Issue: When each of the arrays in the secret are processed during node pod startup, host objects are getting created with correct protocol on each of the arrays. But the flags that are used to determine the protocol are saved in the Node's controller service, which is later used during _NodeStageVolume_ and other Node calls. So, depending on whichever array was last processed, that protocol is used for these Node calls. This causes the 'unable to find device' failure.

Fix: Similar to how the FC/NVMe initiators are maintained in the service for each of the arrays as 'map', NVMe and FC protocol flags are maintained in the same way for each of the arrays.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1539 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate (pkg/node 82.0% to 82.3%)
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?

K8s cluster setup with iSCSI and NVMe pre-req steps. Added 2 arrays in the secret with NVMe/TCP for array-1 and iSCSI for array-2. Host objects are created on both the arrays as expected once node pods are deployed.

Provisioned PV with SC referring to NVMe/array-1. Issue was reproduced.
With the fix, the steps are repeated and it worked.

Provisioning from other array with iSCSI protocol too worked. App pods are in running state and can write data to it.

tests/simple.yaml also passed.

cert-csi suites passed for both NVMe and iSCSI based storage classes.

Logs and reports are attached to ticket 28493.

```
[root@master-1-SPknwwOOoaVwH my-configs]# k get pv
NAME                   CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM          STORAGECLASS         VOLUMEATTRIBUTESCLASS   REASON   AGE
csivol-sl-5b1ed06362   11Gi       RWO            Delete           Bound    nsps2/pvcps2   powerstore-iscsi     <unset>                          2m20s
csivol-sl-aba3a6f497   9Gi        RWO            Delete           Bound    nsps1/pvcps1   powerstore-nvmetcp   <unset>                          50m
[root@master-1-SPknwwOOoaVwH my-configs]#
[root@master-1-SPknwwOOoaVwH my-configs]#
[root@master-1-SPknwwOOoaVwH my-configs]# k get pvc -A
NAMESPACE   NAME     STATUS   VOLUME                 CAPACITY   ACCESS MODES   STORAGECLASS         VOLUMEATTRIBUTESCLASS   AGE
nsps1       pvcps1   Bound    csivol-sl-aba3a6f497   9Gi        RWO            powerstore-nvmetcp   <unset>                 50m
nsps2       pvcps2   Bound    csivol-sl-5b1ed06362   11Gi       RWO            powerstore-iscsi     <unset>                 2m24s
[root@master-1-SPknwwOOoaVwH my-configs]#
[root@master-1-SPknwwOOoaVwH my-configs]#
[root@master-1-SPknwwOOoaVwH my-configs]# k get pods -A | grep nsps
nsps1                         powerstoretest-0                                        1/1     Running   0             51m
nsps2                         powerstoretest-0                                        1/1     Running   0             2m32s
[root@master-1-SPknwwOOoaVwH my-configs]#
```