### PR TITLE
Initialize hosts during dynamic secret update

### DIFF
--- a/cmd/csi-powerstore/main.go
+++ b/cmd/csi-powerstore/main.go
@@ -154,6 +154,10 @@ func main() {
 			if err != nil {
 				log.Fatalf("couldn't initialize arrays in node service: %s", err.Error())
 			}
+			err = nodeService.Init()
+			if err != nil {
+				log.Fatalf("couldn't create node service: %s", err.Error())
+			}
 		}
 	})
 


### PR DESCRIPTION
# Description
Formerly, the secret watcher was updating the array object when the secret config changed. In the case where a new array was added to the secret, only the array object was updated to add the new array info, and hosts were not configured for the node in the PowerStore system. 

This change will re-initialize the driver node container when a changes is detected by the secret watcher, setting up the hosts for the node in the PowerStore system, avoiding a pod restart to accomplish the same.

# GitHub Issues

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1538 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# Testing
### Procedure
- Install the driver with one array in the secret, configured for NVMeTCP.
- Create a corresponding storage class for the array.
- Execute cert-csi test suite against the storage class configured for the array using NVMeTCP.
- Observe results. Should pass all tests at 100%.
- Execute the command to update the secret, adding a second PowerStore array configured for ISCSI, setting the second array as default, and re-configuring the first array to no longer be default.
- Create a corresponding storage class for the second array.
- Execute cert-csi test suite against the storage class configured for the new array using ISCSI.
- Observer results. Should pass all tests at 100%.

### Results
Test with only one array configured for NVMeTCP
![image](https://github.com/user-attachments/assets/9c81e1dd-4c44-47f2-9421-519a6869d619)
![image](https://github.com/user-attachments/assets/b656415d-18d9-41c6-a35e-4fffe39728ec)
Test with two arrays in the secret, the second set as default and configured for ISCSI
![image](https://github.com/user-attachments/assets/c7f7437c-2ad7-4c60-b7e7-4d64ce4a4527)
![image](https://github.com/user-attachments/assets/6a91aed0-2cf6-44fd-9b5d-3eb8ad88a6d0)

### Configs
cert-csi-config.yaml
``` yaml
storageClasses:
  - name: powerstore-nvmetcp
    minSize: 5Gi
    rawBlock: true
    expansion: true
    clone: true
    snapshot: false
    RWX: false
    RWXOP: true
  - name: powerstore-iscsi
    minSize: 5Gi
    rawBlock: true
    expansion: true
    clone: true
    snapshot: false
    RWX: false
    RWXOP: true
```
powerstore-nvmetcp.yaml
``` yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: powerstore-nvmetcp
parameters:
  arrayID: "array-id-1"
  csi.storage.k8s.io/fstype: ext4
provisioner: csi-powerstore.dellemc.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
allowVolumeExpansion: true
```
powerstore-iscsi.yaml
``` yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: powerstore-iscsi
parameters:
  arrayID: "array-id-2"
  csi.storage.k8s.io/fstype: ext4
provisioner: csi-powerstore.dellemc.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
allowVolumeExpansion: true
```
secret-one.yaml
``` yaml
arrays:
   - endpoint: "https://<array-ip-1>/api/rest"
     globalID: "array-id-1"
     username: "username"
     password: "password"
     skipCertificateValidation: true
     blockProtocol: "NVMeTCP"
     nasName: "nas-name"
     isDefault: true
```
secret-two.yaml
``` yaml
arrays:
   - endpoint: "https://<array-ip-1>/api/rest"
     globalID: "array-id-1"
     username: "username"
     password: "password"
     skipCertificateValidation: true
     blockProtocol: "NVMeTCP"
     nasName: "nas-name"
   - endpoint: "https://<array-ip-2>/api/rest"
     globalID: "array-id-2"
     username: "username"
     password: "password"
     skipCertificateValidation: true
     isDefault: true
     blockProtocol: "ISCSI"
     nasName: "nas-name"