### PR TITLE
Updates for quay.io registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ service/test/
 
 # IDE
 .idea
+.vscode
 
 # gosec
 gosec.log

--- a/dell-csi-helm-installer/csi-offline-bundle.md
+++ b/dell-csi-helm-installer/csi-offline-bundle.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The `csi-offline-bundle.sh` script can be used to create a package for the offline installation of Dell CSI storage providers for deployment via Helm. 
+The `csi-offline-bundle.sh` script can be used to create a package for the offline installation of Dell CSI storage providers for deployment via Helm.
 
 This includes the following drivers:
 * [PowerFlex](https://github.com/dell/csi-vxflexos)
@@ -78,30 +78,30 @@ For example, here is the output of a request to build an offline bundle for the 
 *
 * Pulling and saving container images
 
-   dellemc/csi-isilon:v2.10.1
-   dellemc/csi-metadata-retriever:v1.6.0
-   dellemc/csipowermax-reverseproxy:v2.6.0
-   dellemc/csi-powermax:v2.10.1
-   dellemc/csi-powerstore:v2.10.1
-   dellemc/csi-unity:v2.10.1
-   dellemc/csi-vxflexos:v2.10.1
-   dellemc/csm-authorization-sidecar:v1.9.0
-   dellemc/csm-metrics-powerflex:v1.5.0
-   dellemc/csm-metrics-powerscale:v1.2.0
-   dellemc/csm-topology:v1.5.0
-   dellemc/dell-csi-replicator:v1.7.0
-   dellemc/dell-replication-controller:v1.7.0
-   dellemc/sdc:4.5
-   docker.io/dellemc/dell-csm-operator:v1.3.0
+   quay.io/dell/container-storage-module/csi-isilon:v2.12.0
+   quay.io/dell/container-storage-module/csi-metadata-retriever:v1.9.0
+   quay.io/dell/container-storage-module/csipowermax-reverseproxy:v2.11.0
+   quay.io/dell/container-storage-module/csi-powermax:v2.12.0
+   quay.io/dell/container-storage-module/csi-powerstore:v2.12.0
+   quay.io/dell/container-storage-module/csi-unity:v2.12.0
+   quay.io/dell/container-storage-module/csi-vxflexos:v2.12.0
+   quay.io/dell/container-storage-module/csm-authorization-sidecar:v1.12.0
+   quay.io/dell/container-storage-module/csm-metrics-powerflex:v1.10.0
+   quay.io/dell/container-storage-module/csm-metrics-powerscale:v1.7.0
+   quay.io/dell/container-storage-module/csm-topology:v1.10.0
+   quay.io/dell/container-storage-module/dell-csi-replicator:v1.10.0
+   quay.io/dell/container-storage-module/dell-replication-controller:v1.10.0
+   quay.io/dell/container-storage-modules/sdc:4.5
+   quay.io/dell/container-storage-modules/dell-csm-operator:v1.7.0
    gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
    nginxinc/nginx-unprivileged:1.20
    otel/opentelemetry-collector:0.42.0
    registry.k8s.io/sig-storage/csi-attacher:v4.3.0
-   registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0
-   registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
-   registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
-   registry.k8s.io/sig-storage/csi-resizer:v1.8.0
-   registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
+   registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
+   registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+   registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+   registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+   registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
 
 *
 * Copying necessary files
@@ -176,32 +176,32 @@ Preparing a offline bundle for installation
 *
 * Loading docker images
 
-Loaded image: docker.io/dellemc/csi-powerstore:v2.10.1
-Loaded image: docker.io/dellemc/csi-isilon:v2.10.1
+Loaded image: quay.io/dell/container-storage-modules/csi-powerstore:v2.12.0
+Loaded image: quay.io/dell/container-storage-modules/csi-isilon:v2.12.0
 ...
 ...
-Loaded image: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
-Loaded image: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.2
+Loaded image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+Loaded image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
 
 *
 * Tagging and pushing images
 
-   dellemc/csi-isilon:v2.10.1 -> localregistry:5000/dell-csm-operator/csi-isilon:v2.10.1
-   dellemc/csi-metadata-retriever:v1.6.0 -> localregistry:5000/dell-csm-operator/csi-metadata-retriever:v1.6.0
+   quay.io/dell/container-storage-modules/csi-isilon:v2.12.0 -> localregistry:5000/dell-csm-operator/csi-isilon:v2.12.0
+   quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.9.0 -> localregistry:5000/dell-csm-operator/csi-metadata-retriever:v1.9.0
    ...
    ...
-   registry.k8s.io/sig-storage/csi-resizer:v1.9.2 -> localregistry:5000/dell-csm-operator/csi-resizer:v1.9.2
-   registry.k8s.io/sig-storage/csi-snapshotter:v6.3.2 -> localregistry:5000/dell-csm-operator/csi-snapshotter:v6.3.2
+   registry.k8s.io/sig-storage/csi-resizer:v1.12.0 -> localregistry:5000/dell-csm-operator/csi-resizer:v1.12.0
+   registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0 -> localregistry:5000/dell-csm-operator/csi-snapshotter:v8.1.0
 
 *
 * Preparing files within /root/dell-csm-operator-bundle
 
-   changing: dellemc/csi-isilon:v2.10.1 -> localregistry:5000/dell-csm-operator/csi-isilon:v2.10.1
-   changing: dellemc/csi-metadata-retriever:v1.6.0 -> localregistry:5000/dell-csm-operator/csi-metadata-retriever:v1.6.0
+   changing: quay.io/dell/container-storage-modules/csi-isilon:v2.12.0 -> localregistry:5000/dell-csm-operator/csi-isilon:v2.12.0
+   changing: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.9.0 -> localregistry:5000/dell-csm-operator/csi-metadata-retriever:v1.9.0
    ...
    ...
-   changing: registry.k8s.io/sig-storage/csi-resizer:v1.9.2 -> localregistry:5000/dell-csm-operator/csi-resizer:v1.9.2
-   changing: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.2 -> localregistry:5000/dell-csm-operator/csi-snapshotter:v6.3.2
+   changing: registry.k8s.io/sig-storage/csi-resizer:v1.12.0 -> localregistry:5000/dell-csm-operator/csi-resizer:v1.12.0
+   changing: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0 -> localregistry:5000/dell-csm-operator/csi-snapshotter:v8.1.0
 
 *
 * Complete

--- a/tests/sanity/helm/sanity-csi-powerstore/values.yaml
+++ b/tests/sanity/helm/sanity-csi-powerstore/values.yaml
@@ -40,7 +40,7 @@ images:
   replication: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.10.0
   vgsnapshotter: quay.io/dell/container-storage-modules/csi-volumegroup-snapshotter:v1.7.0
   podmon: quay.io/dell/container-storage-modules/podmon:v1.11.0
-  metadataretriever: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.8.0
+  metadataretriever: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.9.0
 
 # Specify kubelet config dir path.
 # Ensure that the config.yaml file is present at this path.

--- a/tests/sanity/helm/sanity-csi-powerstore/values.yaml
+++ b/tests/sanity/helm/sanity-csi-powerstore/values.yaml
@@ -37,7 +37,7 @@ images:
   healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
 
   # CSM sidecars
-  replication: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.9.0
+  replication: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.10.0
   vgsnapshotter: quay.io/dell/container-storage-modules/csi-volumegroup-snapshotter:v1.7.0
   podmon: quay.io/dell/container-storage-modules/podmon:v1.11.0
   metadataretriever: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.8.0

--- a/tests/sanity/helm/sanity-csi-powerstore/values.yaml
+++ b/tests/sanity/helm/sanity-csi-powerstore/values.yaml
@@ -1,5 +1,3 @@
-#
-#
 # Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,26 +21,26 @@
 driverName: "csi-powerstore.dellemc.com"
 # "version" is used to verify the values file matches driver version
 # Not recommend to change
-version: v2.9.0
+version: v2.12.0
 
 # "images" defines every container images used for the driver and its sidecars.
 #  To use your own images, or a private registry, change the values here.
 images:
   # "driver" defines the container image, used for the driver container.
-  driver: dellemc/csi-powerstore:v2.9.0
+  driver: quay.io/dell/container-storage-modules/csi-powerstore:v2.12.0
   # CSI sidecars
-  attacher: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
-  provisioner: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
-  snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.2
-  resizer: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
-  registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
-  healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
+  attacher: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+  provisioner: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+  snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+  resizer: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+  registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+  healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
 
   # CSM sidecars
-  replication: dellemc/dell-csi-replicator:v1.7.0
-  vgsnapshotter: dellemc/csi-volumegroup-snapshotter:v1.4.0
-  podmon: dellemc/podmon:v1.8.0
-  metadataretriever: dellemc/csi-metadata-retriever:v1.6.0
+  replication: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.9.0
+  vgsnapshotter: quay.io/dell/container-storage-modules/csi-volumegroup-snapshotter:v1.7.0
+  podmon: quay.io/dell/container-storage-modules/podmon:v1.11.0
+  metadataretriever: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.8.0
 
 # Specify kubelet config dir path.
 # Ensure that the config.yaml file is present at this path.


### PR DESCRIPTION
# Description
* Use quay.io locations for images referenced on docker.io.
* Add a flag for pointing to the nightly images in the offline bundler.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1435|

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Ran through the offline creation and prep steps. Manual inspection of modified values.yaml to check that the quay.io locations are referenced only for the CSM images. Other registry location are not modified.
- [X] Performed offline install of the driver.
