### PR TITLE
Error logging for duplicate host nqns

### DIFF
--- a/mocks/NodeLabelsRetriever.go
+++ b/mocks/NodeLabelsRetriever.go
@@ -59,25 +59,25 @@ func (_m *NodeLabelsRetrieverInterface) BuildConfigFromFlags(masterURL string, k
 	return r0, r1
 }
 
-// GetNVMeUUIDs provides a mock function with given fields: ctx, k8sclientset, kubeNodeName
-func (_m *NodeLabelsRetrieverInterface) GetNVMeUUIDs(ctx context.Context, k8sclientset *kubernetes.Clientset, kubeNodeName string) (map[string]string, error) {
-	ret := _m.Called(k8sclientset, ctx, kubeNodeName)
+// GetNVMeUUIDs provides a mock function with given fields: ctx, k8sclientset
+func (_m *NodeLabelsRetrieverInterface) GetNVMeUUIDs(ctx context.Context, k8sclientset *kubernetes.Clientset) (map[string]string, error) {
+	ret := _m.Called(k8sclientset, ctx)
 
 	var r0 map[string]string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset, context.Context, string) (map[string]string, error)); ok {
-		return rf(k8sclientset, ctx, kubeNodeName)
+	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset, context.Context) (map[string]string, error)); ok {
+		return rf(k8sclientset, ctx)
 	}
-	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset, context.Context, string) map[string]string); ok {
-		r0 = rf(k8sclientset, ctx, kubeNodeName)
+	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset, context.Context) map[string]string); ok {
+		r0 = rf(k8sclientset, ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*kubernetes.Clientset, context.Context, string) error); ok {
-		r1 = rf(k8sclientset, ctx, kubeNodeName)
+	if rf, ok := ret.Get(1).(func(*kubernetes.Clientset, context.Context) error); ok {
+		r1 = rf(k8sclientset, ctx)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/NodeLabelsRetriever.go
+++ b/mocks/NodeLabelsRetriever.go
@@ -59,6 +59,33 @@ func (_m *NodeLabelsRetrieverInterface) BuildConfigFromFlags(masterURL string, k
 	return r0, r1
 }
 
+// GetNVMeUUIDs provides a mock function with given fields: ctx, k8sclientset, kubeNodeName
+func (_m *NodeLabelsRetrieverInterface) GetNVMeUUIDs(ctx context.Context, k8sclientset *kubernetes.Clientset, kubeNodeName string) (map[string]string, error) {
+	ret := _m.Called(k8sclientset, ctx, kubeNodeName)
+
+	var r0 map[string]string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset, context.Context, string) (map[string]string, error)); ok {
+		return rf(k8sclientset, ctx, kubeNodeName)
+	}
+	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset, context.Context, string) map[string]string); ok {
+		r0 = rf(k8sclientset, ctx, kubeNodeName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*kubernetes.Clientset, context.Context, string) error); ok {
+		r1 = rf(k8sclientset, ctx, kubeNodeName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+
 // GetNodeLabels provides a mock function with given fields: ctx, k8sclientset, kubeNodeName
 func (_m *NodeLabelsRetrieverInterface) GetNodeLabels(ctx context.Context, k8sclientset *kubernetes.Clientset, kubeNodeName string) (map[string]string, error) {
 	ret := _m.Called(k8sclientset, ctx, kubeNodeName)

--- a/mocks/NodeLabelsRetriever.go
+++ b/mocks/NodeLabelsRetriever.go
@@ -85,7 +85,6 @@ func (_m *NodeLabelsRetrieverInterface) GetNVMeUUIDs(ctx context.Context, k8scli
 	return r0, r1
 }
 
-
 // GetNodeLabels provides a mock function with given fields: ctx, k8sclientset, kubeNodeName
 func (_m *NodeLabelsRetrieverInterface) GetNodeLabels(ctx context.Context, k8sclientset *kubernetes.Clientset, kubeNodeName string) (map[string]string, error) {
 	ret := _m.Called(k8sclientset, ctx, kubeNodeName)

--- a/pkg/common/k8sutils/k8sutils.go
+++ b/pkg/common/k8sutils/k8sutils.go
@@ -35,7 +35,7 @@ type NodeLabelsRetrieverInterface interface {
 	GetNodeLabels(ctx context.Context, k8sclientset *kubernetes.Clientset, kubeNodeName string) (map[string]string, error)
 }
 
-// NodeLabelsRetrieverInterface defines the methods for retrieving Kubernetes Node Labels
+// NodeLabelsModifierInterface defines the methods for retrieving Kubernetes Node Labels
 type NodeLabelsModifierInterface interface {
 	AddNVMeLabels(ctx context.Context, k8sclientset *kubernetes.Clientset, kubeNodeName string, labelKey string, labelValue []string) error
 }

--- a/pkg/common/k8sutils/k8sutils.go
+++ b/pkg/common/k8sutils/k8sutils.go
@@ -47,8 +47,10 @@ type NodeLabelsRetrieverImpl struct{}
 type NodeLabelsModifierImpl struct{}
 
 // NodeLabelsRetriever is the actual instance of NodeLabelsRetrieverInterface which is used to retrieve the node labels
-var NodeLabelsRetriever NodeLabelsRetrieverInterface
-var NodeLabelsModifier NodeLabelsModifierInterface
+var (
+	NodeLabelsRetriever NodeLabelsRetrieverInterface
+	NodeLabelsModifier  NodeLabelsModifierInterface
+)
 
 func init() {
 	NodeLabelsRetriever = new(NodeLabelsRetrieverImpl)

--- a/pkg/common/k8sutils/k8sutils.go
+++ b/pkg/common/k8sutils/k8sutils.go
@@ -128,8 +128,17 @@ func (svc *NodeLabelsModifierImpl) AddNVMeLabels(ctx context.Context, k8sclients
 		node.Labels = make(map[string]string)
 	}
 
-	// Update the node with the new label
-	node.Labels[labelKey] = strings.Join(labelValue, ",")
+	// Fetch the uuids from hostnqns
+	var uuids []string
+	for _, nqn := range labelValue {
+		parts := strings.Split(nqn, ":")
+		if len(parts) == 3 { // nqn format is nqn.yyyy-mm.nvmexpress:uuid:xxxx-yyyy-zzzz
+			uuids = append(uuids, parts[2]) // Extract the UUID
+		}
+	}
+
+	// Update the node with the new labels
+	node.Labels[labelKey] = strings.Join(uuids, ",")
 	_, err = k8sclientset.CoreV1().Nodes().Update(ctx, node, v1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update node %s labels: %v", kubeNodeName, err.Error())

--- a/pkg/common/k8sutils/k8sutils.go
+++ b/pkg/common/k8sutils/k8sutils.go
@@ -33,7 +33,7 @@ type NodeLabelsRetrieverInterface interface {
 	InClusterConfig() (*rest.Config, error)
 	NewForConfig(config *rest.Config) (*kubernetes.Clientset, error)
 	GetNodeLabels(ctx context.Context, k8sclientset *kubernetes.Clientset, kubeNodeName string) (map[string]string, error)
-	GetNVMeUUIDs(ctx context.Context, k8sclientset *kubernetes.Clientset, kubeNodeName string) (map[string]string, error)
+	GetNVMeUUIDs(ctx context.Context, k8sclientset *kubernetes.Clientset) (map[string]string, error)
 }
 
 // NodeLabelsModifierInterface defines the methods for retrieving Kubernetes Node Labels
@@ -150,14 +150,14 @@ func (svc *NodeLabelsModifierImpl) AddNVMeLabels(ctx context.Context, k8sclients
 }
 
 // GetNVMeUUIDs returns map of hosts with their hostnqn uuids
-func (svc *NodeLabelsRetrieverImpl) GetNVMeUUIDs(ctx context.Context, k8sclientset *kubernetes.Clientset, kubeNodeName string) (map[string]string, error) {
+func (svc *NodeLabelsRetrieverImpl) GetNVMeUUIDs(ctx context.Context, k8sclientset *kubernetes.Clientset) (map[string]string, error) {
 	nodeUUIDs := make(map[string]string)
 	if k8sclientset == nil {
 		return nodeUUIDs, fmt.Errorf("k8sclientset is nil")
 	}
 
 	// Retrieve the list of nodes
-	nodes, err := k8sclientset.CoreV1().Nodes().List(context.Background(), v1.ListOptions{})
+	nodes, err := k8sclientset.CoreV1().Nodes().List(ctx, v1.ListOptions{})
 	if err != nil {
 		return nodeUUIDs, fmt.Errorf("failed to get node list: %v", err.Error())
 	}
@@ -194,11 +194,11 @@ func AddNVMeLabels(ctx context.Context, kubeConfigPath string, kubeNodeName stri
 }
 
 // GetNVMeUUIDs checks for duplicate hostnqn uuid labels in the k8s node
-func GetNVMeUUIDs(ctx context.Context, kubeConfigPath string, kubeNodeName string) (map[string]string, error) {
+func GetNVMeUUIDs(ctx context.Context, kubeConfigPath string) (map[string]string, error) {
 	k8sclientset, err := CreateKubeClientSet(kubeConfigPath)
 	if err != nil {
 		return map[string]string{}, err
 	}
 
-	return NodeLabelsRetriever.GetNVMeUUIDs(ctx, k8sclientset, kubeNodeName)
+	return NodeLabelsRetriever.GetNVMeUUIDs(ctx, k8sclientset)
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -256,7 +256,7 @@ func (s *Service) checkForDuplicateUUIDs() {
 	duplicateUUIDs := make(map[string]string)
 
 	var err error
-	nodeUUIDs, err = k8sutils.GetNVMeUUIDs(context.Background(), s.opts.KubeConfigPath, s.opts.KubeNodeName)
+	nodeUUIDs, err = k8sutils.GetNVMeUUIDs(context.Background(), s.opts.KubeConfigPath)
 	if err != nil {
 		log.Errorf("Unable to check uuids")
 		return

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -125,6 +125,11 @@ func (s *Service) Init() error {
 		return nil
 	}
 
+	err = k8sutils.AddNVMeLabels(ctx, s.opts.KubeConfigPath, s.opts.KubeNodeName, "hostnqn-uuid", nvmeInitiators)
+	if err != nil {
+		log.Warnf("Unable to add hostnqn uuid label for node %s: %v", s.opts.KubeNodeName, err.Error())
+	}
+
 	// Setup host on each of available arrays
 	for _, arr := range s.Arrays() {
 		if arr.BlockProtocol == common.NoneTransport {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1466,7 +1466,7 @@ func (s *Service) setupHost(initiators []string, client gopowerstore.Client, arr
 		return fmt.Errorf("nodeID not set")
 	}
 
-	if s.useNVME {
+	if s.useNVME[arrayID] {
 		// Initialize the Kubernetes client
 		k8sclientset, err := k8sutils.CreateKubeClientSet(s.opts.KubeConfigPath)
 		if err != nil {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -273,7 +273,7 @@ func setDefaultNodeLabelsRetrieverMock() {
 	nodeLabelsRetrieverMock.On("GetNodeLabels", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	nodeLabelsRetrieverMock.On("InClusterConfig", mock.Anything).Return(nil, nil)
 	nodeLabelsRetrieverMock.On("NewForConfig", mock.Anything).Return(nil, nil)
-	nodeLabelsRetrieverMock.On("GetNVMeUUIDs", mock.Anything, mock.Anything, mock.Anything).Return(map[string]string{}, nil)
+	nodeLabelsRetrieverMock.On("GetNVMeUUIDs", mock.Anything, mock.Anything).Return(map[string]string{}, nil)
 }
 
 var _ = ginkgo.Describe("CSINodeService", func() {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -318,6 +318,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 				clientMock.On("SetCustomHTTPHeaders", mock.Anything).Return(nil)
 				clientMock.On("CreateHost", mock.Anything, mock.Anything).
 					Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+				setDefaultNodeLabelsRetrieverMock()
 				nodeSvc.opts.NodeNamePrefix = ""
 				err := nodeSvc.Init()
 				gomega.Expect(err).To(gomega.BeNil())
@@ -329,6 +330,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 				nodeSvc.nodeID = ""
 
 				fsMock.On("ReadFile", mock.Anything).Return([]byte("my-host-id"), errors.New("no such file"))
+				setDefaultNodeLabelsRetrieverMock()
 
 				err := nodeSvc.Init()
 				gomega.Expect(err.Error()).To(gomega.ContainSubstring("no such file"))
@@ -368,6 +370,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 					}}, nil)
 				clientMock.On("CreateHost", mock.Anything, mock.Anything).
 					Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+				setDefaultNodeLabelsRetrieverMock()
 				nodeSvc.opts.NodeNamePrefix = ""
 				err := nodeSvc.Init()
 				gomega.Expect(err.Error()).To(gomega.ContainSubstring("Could not connect to PowerStore array"))
@@ -407,6 +410,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 					}}, nil)
 				clientMock.On("CreateHost", mock.Anything, mock.Anything).
 					Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+				setDefaultNodeLabelsRetrieverMock()
 				nodeSvc.opts.NodeNamePrefix = ""
 				err := nodeSvc.Init()
 				gomega.Expect(err.Error()).To(gomega.ContainSubstring("node name prefix is too long"))
@@ -438,6 +442,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 							},
 							Name: "host-name",
 						}, nil)
+					setDefaultNodeLabelsRetrieverMock()
 					err := nodeSvc.Init()
 					gomega.Expect(err).To(gomega.BeNil())
 				})
@@ -462,6 +467,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 
 					clientMock.On("ModifyHost", mock.Anything, mock.Anything, "host-id").
 						Return(gopowerstore.CreateResponse{}, nil)
+					setDefaultNodeLabelsRetrieverMock()
 
 					err := nodeSvc.Init()
 					gomega.Expect(err).To(gomega.BeNil())
@@ -501,6 +507,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 						}}, nil)
 					clientMock.On("ModifyHost", mock.Anything, mock.Anything, "host-id").
 						Return(gopowerstore.CreateResponse{ID: "host-id"}, nil)
+					setDefaultNodeLabelsRetrieverMock()
 
 					err := nodeSvc.Init()
 					gomega.Expect(err).To(gomega.BeNil())
@@ -540,6 +547,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 						}}, nil)
 					clientMock.On("ModifyHost", mock.Anything, mock.Anything, "host-id").
 						Return(gopowerstore.CreateResponse{ID: "host-id"}, nil)
+					setDefaultNodeLabelsRetrieverMock()
 
 					err := nodeSvc.Init()
 					gomega.Expect(err).To(gomega.BeNil())
@@ -590,6 +598,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 				clientMock.On("SetCustomHTTPHeaders", mock.Anything).Return(nil)
 				clientMock.On("CreateHost", mock.Anything, mock.Anything).
 					Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+				setDefaultNodeLabelsRetrieverMock()
 
 				err := nodeSvc.Init()
 				gomega.Expect(err).To(gomega.BeNil())
@@ -635,6 +644,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 				clientMock.On("SetCustomHTTPHeaders", mock.Anything).Return(nil)
 				clientMock.On("CreateHost", mock.Anything, mock.Anything).
 					Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+				setDefaultNodeLabelsRetrieverMock()
 
 				err := nodeSvc.Init()
 				gomega.Expect(err).To(gomega.BeNil())
@@ -676,6 +686,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 				clientMock.On("SetCustomHTTPHeaders", mock.Anything).Return(nil)
 				clientMock.On("CreateHost", mock.Anything, mock.Anything).
 					Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+				setDefaultNodeLabelsRetrieverMock()
 
 				err := nodeSvc.Init()
 				gomega.Expect(err).To(gomega.BeNil())
@@ -719,6 +730,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 				clientMock.On("SetCustomHTTPHeaders", mock.Anything).Return(nil)
 				clientMock.On("CreateHost", mock.Anything, mock.Anything).
 					Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+				setDefaultNodeLabelsRetrieverMock()
 
 				err := nodeSvc.Init()
 				gomega.Expect(err).To(gomega.BeNil())
@@ -4081,6 +4093,7 @@ var _ = ginkgo.Describe("CSINodeService", func() {
 			clientMock.On("SetCustomHTTPHeaders", mock.Anything).Return(nil)
 			clientMock.On("CreateHost", mock.Anything, mock.Anything).
 				Return(gopowerstore.CreateResponse{ID: validHostID}, nil)
+			setDefaultNodeLabelsRetrieverMock()
 			nodeSvc.opts.NodeNamePrefix = ""
 			nodeSvc.Init()
 

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -273,6 +273,7 @@ func setDefaultNodeLabelsRetrieverMock() {
 	nodeLabelsRetrieverMock.On("GetNodeLabels", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	nodeLabelsRetrieverMock.On("InClusterConfig", mock.Anything).Return(nil, nil)
 	nodeLabelsRetrieverMock.On("NewForConfig", mock.Anything).Return(nil, nil)
+	nodeLabelsRetrieverMock.On("GetNVMeUUIDs", mock.Anything, mock.Anything, mock.Anything).Return(map[string]string{}, nil)
 }
 
 var _ = ginkgo.Describe("CSINodeService", func() {


### PR DESCRIPTION
# Description
Error logging for duplicate host nqns when found on the kubernetes nodes.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1530 | 

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested on OCP cluster where duplicate host nqns were present in case of NVMe protocol. Error logged in that case.
