### PR TITLE
fix nvme block volume resize

### DIFF
--- a/cmd/csi-powerstore/main.go
+++ b/cmd/csi-powerstore/main.go
@@ -86,7 +86,7 @@ func init() {
 }
 
 func main() {
-	f := &fs.Fs{Util: &gofsutil.FS{}}
+	f := &fs.Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}}
 
 	common.RmSockFile(f)
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.6.0
 	github.com/dell/gobrick v1.11.5-0.20241014113235-06cfe9928229
 	github.com/dell/gocsi v1.11.0
-	github.com/dell/gofsutil v1.16.1
+	github.com/dell/gofsutil v1.16.2-0.20241024070128-65a51f273f8a
 	github.com/dell/goiscsi v1.9.0
 	github.com/dell/gonvme v1.8.1
 	github.com/dell/gopowerstore v1.15.2-0.20241008144633-6990d1b86e5b

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/dell/gobrick v1.11.5-0.20241014113235-06cfe9928229 h1:jer/8oHRkUe3Kgc
 github.com/dell/gobrick v1.11.5-0.20241014113235-06cfe9928229/go.mod h1:+qnDjbft08dV0s5BWG/R6KUFnS3nxJRqfALV1ficbWI=
 github.com/dell/gocsi v1.11.0 h1:P84VOPd1V55JQjx4tfd/6QOlVQRQkYUqmGqbzPKeyUQ=
 github.com/dell/gocsi v1.11.0/go.mod h1:LzGAsEIjBxVXJuabzsG3/MsdCOczxDE1IWOBxzXIUhw=
-github.com/dell/gofsutil v1.16.1 h1:BzdxMdIDgKzinlYyi5G3pi27Jw0cmtqRHM5UsIkoE+w=
-github.com/dell/gofsutil v1.16.1/go.mod h1:bZ43qAOqKzGJxCRvkTVD7GCFMNkK37ur84mmMuxQshE=
+github.com/dell/gofsutil v1.16.2-0.20241024070128-65a51f273f8a h1:20B30iO7h5cv/DtC5Hts3iPxMOsrL/V+uHiAyQRfnlY=
+github.com/dell/gofsutil v1.16.2-0.20241024070128-65a51f273f8a/go.mod h1:PN2hWl/pVLQiTsFR0X1x+GfhfOrfW8pGgH5xGcGMeFs=
 github.com/dell/goiscsi v1.9.0 h1:VvMHbAO4vk80oc/TAbQPYlxysscCqVBW78GyPoUxgik=
 github.com/dell/goiscsi v1.9.0/go.mod h1:NI/W/0O1UrMW2zVdMxy4z395Jn0r7utH6RQDFSZiFyQ=
 github.com/dell/gonvme v1.8.1 h1:46M5lPqj7+Xjen+qxooRN9cx/+uJG4xtK9TpwduWDgE=

--- a/pkg/array/array_test.go
+++ b/pkg/array/array_test.go
@@ -84,7 +84,7 @@ func TestGetPowerStoreArrays(t *testing.T) {
 	}{
 		{
 			name:    "two arrays",
-			args:    args{data: "./testdata/two-arr.yaml", fs: &fs.Fs{Util: &gofsutil.FS{}}},
+			args:    args{data: "./testdata/two-arr.yaml", fs: &fs.Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}}},
 			wantErr: false,
 			want: map[string]*array.PowerStoreArray{
 				"gid1": {
@@ -107,7 +107,7 @@ func TestGetPowerStoreArrays(t *testing.T) {
 		},
 		{
 			name:    "one array",
-			args:    args{data: "./testdata/one-arr.yaml", fs: &fs.Fs{Util: &gofsutil.FS{}}},
+			args:    args{data: "./testdata/one-arr.yaml", fs: &fs.Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}}},
 			wantErr: false,
 			want: map[string]*array.PowerStoreArray{
 				"gid1": {
@@ -122,7 +122,7 @@ func TestGetPowerStoreArrays(t *testing.T) {
 		},
 		{
 			name:    "empty arrays",
-			args:    args{data: "./testdata/no-arr.yaml", fs: &fs.Fs{Util: &gofsutil.FS{}}},
+			args:    args{data: "./testdata/no-arr.yaml", fs: &fs.Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}}},
 			wantErr: false,
 			want:    map[string]*array.PowerStoreArray{},
 		},
@@ -169,20 +169,20 @@ func TestGetPowerStoreArrays(t *testing.T) {
 	})
 
 	t.Run("incorrect endpoint", func(t *testing.T) {
-		f := &fs.Fs{Util: &gofsutil.FS{}}
+		f := &fs.Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}}
 		_, _, _, err := array.GetPowerStoreArrays(f, "./testdata/incorrect-endpoint.yaml")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "can't get ips from endpoint")
 	})
 
 	t.Run("invalid endpoint", func(t *testing.T) {
-		f := &fs.Fs{Util: &gofsutil.FS{}}
+		f := &fs.Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}}
 		_, _, _, err := array.GetPowerStoreArrays(f, "./testdata/invalid-endpoint.yaml")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "can't get ips from endpoint")
 	})
 	t.Run("no global ID", func(t *testing.T) {
-		f := &fs.Fs{Util: &gofsutil.FS{}}
+		f := &fs.Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}}
 		_, _, _, err := array.GetPowerStoreArrays(f, "./testdata/no-globalID.yaml")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no GlobalID field found in config.yaml")
@@ -190,7 +190,7 @@ func TestGetPowerStoreArrays(t *testing.T) {
 
 	t.Run("incorrect throttling limit", func(t *testing.T) {
 		_ = os.Setenv(common.EnvThrottlingRateLimit, "abc")
-		f := &fs.Fs{Util: &gofsutil.FS{}}
+		f := &fs.Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}}
 		_, _, _, err := array.GetPowerStoreArrays(f, "./testdata/one-arr.yaml")
 		assert.NoError(t, err)
 	})
@@ -396,7 +396,7 @@ func TestParseVolumeID(t *testing.T) {
 
 func TestLocker_UpdateArrays(t *testing.T) {
 	lck := array.Locker{}
-	err := lck.UpdateArrays("./testdata/one-arr.yaml", &fs.Fs{Util: &gofsutil.FS{}})
+	err := lck.UpdateArrays("./testdata/one-arr.yaml", &fs.Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}})
 	assert.NoError(t, err)
 	assert.Equal(t, lck.DefaultArray().Endpoint, "https://127.0.0.1/api/rest")
 }

--- a/pkg/common/fs/fs_test.go
+++ b/pkg/common/fs/fs_test.go
@@ -33,7 +33,7 @@ type FsTestSuite struct {
 }
 
 func (suite *FsTestSuite) SetupSuite() {
-	suite.fs = &Fs{Util: &gofsutil.FS{}}
+	suite.fs = &Fs{Util: &gofsutil.FS{SysBlockDir: "/sys/block"}}
 	suite.tmp = "./tmp"
 	err := os.Mkdir(suite.tmp, 0o750)
 	if err != nil {


### PR DESCRIPTION
# Description
This PR fixes nvme block volume expansion

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1534 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested nvme volume expansion
```
 Normal   Started                     70s                  kubelet                  Started container prov-test
 Normal   FileSystemResizeSuccessful  4s                   kubelet                  MountVolume.NodeExpandVolume succeeded for volume "csivol-04c1226784" worker-1-du11li7da0bmb.domain
 Normal   FileSystemResizeSuccessful  4s                   kubelet                  MountVolume.NodeExpandVolume succeeded for volume "csivol-38a71f6a5d" worker-1-du11li7da0bmb.domain
```
- [x] Ran cert-csi successfully 
![image](https://github.com/user-attachments/assets/75d42e7d-2869-40da-ad96-10e951e7f3ab)
