### PR TITLE
Revert "Initialize hosts during dynamic secret update"

### DIFF
--- a/cmd/csi-powerstore/main.go
+++ b/cmd/csi-powerstore/main.go
@@ -154,10 +154,6 @@ func main() {
 			if err != nil {
 				log.Fatalf("couldn't initialize arrays in node service: %s", err.Error())
 			}
-			err = nodeService.Init()
-			if err != nil {
-				log.Fatalf("couldn't create node service: %s", err.Error())
-			}
 		}
 	})
 


### PR DESCRIPTION
# Description
This reverts commit fc8ce02683c165dcefbf21726b2dee8952498e66.

Reverting commit because driver was working as expected.
If a new array is added to the host, a restart of the driver pods is required in order to provide node topology information to kubelet via its `NodeGetInfo()` request. If hosts are configured after the `NodeGetInfo()` request is fulfilled, topology information is not updated on the worker nodes and could cause issues when applying topology constraints.

Documentation will be updated to clarify when dynamic secret update applies and when the driver should be restarted.

# GitHub Issues

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1538 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
## Integration testing with cert-csi
### iscsi
![image](https://github.com/user-attachments/assets/7d6091b0-0811-4f0f-b38e-43b75442102a)
![image](https://github.com/user-attachments/assets/e44a54b8-ff6d-443f-be62-64e0e63a1053)

### nvme tcp
![image](https://github.com/user-attachments/assets/02e4844e-f908-41f2-82cc-901c77a598bf)
![image](https://github.com/user-attachments/assets/d894358e-51fa-45e2-84c0-279ea9d6675a)

### metro replication
![image](https://github.com/user-attachments/assets/b65e0d20-1c8a-4f4d-adf2-19b5e643731a)
![image](https://github.com/user-attachments/assets/6da14284-8ed8-4277-83fd-9f696e752b91)