### PR TITLE
Publish LIST_VOLUMES capability

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1131,6 +1131,7 @@ func (s *Service) ControllerGetCapabilities(_ context.Context, _ *csi.Controller
 	if s.isHealthMonitorEnabled {
 		for _, capability := range []csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_GET_VOLUME,
+			csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES,
 			csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
 		} {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -4375,6 +4375,13 @@ var _ = ginkgo.Describe("CSIControllerService", func() {
 						{
 							Type: &csi.ControllerServiceCapability_Rpc{
 								Rpc: &csi.ControllerServiceCapability_RPC{
+									Type: csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
+								},
+							},
+						},
+						{
+							Type: &csi.ControllerServiceCapability_Rpc{
+								Rpc: &csi.ControllerServiceCapability_RPC{
 									Type: csi.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES,
 								},
 							},


### PR DESCRIPTION
# Description
PR adds LIST_VOLUMES capability to be published by the controller

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1559|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make test
```
go clean -cache; cd ./pkg; go test -race -cover -coverprofile=coverage.out ./...
ok      github.com/dell/csi-powerstore/v2/pkg/array     1.291s  coverage: 92.6% of statements
        github.com/dell/csi-powerstore/v2/pkg/common/k8sutils           coverage: 0.0% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/common    3.216s  coverage: 96.1% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/common/fs 1.221s  coverage: 90.6% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/controller        2.625s  coverage: 90.4% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/identity  1.171s  coverage: 100.0% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/interceptors      3.968s  coverage: 90.1% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/node      3.965s  coverage: 90.1% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/tracer    1.206s  coverage: 100.0% of statements
```

- [x] Installed powerstore driver with health monitor enabled
```
[root@master-1-AevzcJKPoLLnD samples]# kubectl logs powerstore-controller-86fb6dcdd-6bpr8 -n powerstore | grep LIST_VOLUMES
{"level":"info","msg":"/csi.v1.Controller/ControllerGetCapabilities: REP 0004: Capabilities=[rpc:\u003ctype:CREATE_DELETE_VOLUME \u003e  rpc:\u003ctype:PUBLISH_UNPUBLISH_VOLUME \u003e  rpc:\u003ctype:GET_CAPACITY \u003e  rpc:\u003ctype:CREATE_DELETE_SNAPSHOT \u003e  rpc:\u003ctype:LIST_SNAPSHOTS \u003e  rpc:\u003ctype:CLONE_VOLUME \u003e  rpc:\u003ctype:EXPAND_VOLUME \u003e  rpc:\u003ctype:SINGLE_NODE_MULTI_WRITER \u003e  rpc:\u003ctype:GET_VOLUME \u003e  rpc:\u003ctype:LIST_VOLUMES \u003e  rpc:\u003ctype:LIST_VOLUMES_PUBLISHED_NODES \u003e  rpc:\u003ctype:VOLUME_CONDITION \u003e ], XXX_NoUnkeyedLiteral={}, XXX_sizecache=0","time":"2024-11-20T18:44:24.752835769Z"}
```

```
[root@master-1-AevzcJKPoLLnD samples]# kubectl logs powerstore-controller-86fb6dcdd-6bpr8 -n powerstore driver | grep ListVolumes
{"level":"info","msg":"/csi.v1.Controller/ListVolumes: REQ 0024: MaxEntries=0, XXX_NoUnkeyedLiteral={}, XXX_sizecache=0","time":"2024-11-20T18:44:42.940252866Z"}
{"level":"info","msg":"/csi.v1.Controller/ListVolumes: REP 0024: Entries=[volume:\u003ccapacity_bytes:32212254720 volume_id:\"114f5ac0-b012-4552-80b6-f79a0e89bb4c\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"d60bb665-8100-485d-a4ec-ce03f3b5700c\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"4714624a-bd63-47e7-9592-fb14eff48d39\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"5b2f59e6-bb83-43e1-b0b8-8e2bcaf967de\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"b68900a0-9a3d-4102-a27c-c0e76a479d7d\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"00e48a7d-5cd1-4701-bddb-3087b6501a7d\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"e4684e89-008a-4a33-8753-11e436c96035\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"a96f9dad-007e-462e-8039-35c2ece95f72\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"f7e3874f-a594-4e63-875b-c5fc4a25a126\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"412c0e26-b70a-4c9c-a807-0982b0a18406\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"33271c4c-763e-44b8-bfa3-58fc5028000c\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"8ca5d1b1-1937-4258-a2af-050d860023c9\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"8c3eb47e-63bb-4020-aa63-ac7de187c717\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"208886d6-3b39-45ed-9977-4a02130868e3\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"3c3d2895-f8ed-48d9-8fdc-a5aaceb8fc86\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"80fcc2dd-9324-479b-adfb-36d9cc05f4d4\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"ed322bdb-bad5-4c78-b45d-534960f5d796\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"87e7d8b9-121d-411b-87a8-18c147f148b7\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"98f90d84-dfa7-4c97-8156-0eea65a9d335\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"9beeec88-0e07-4436-8146-0c849c71067c\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"bbf7296f-0b54-45bd-83e8-b712f805f002\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"9879e348-8783-4d10-8512-1ad302ffdf2a\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"01b92c19-e5d1-4030-b781-38b9285aed12\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"3014c3da-2ccc-432e-b37a-26be48b1ef99\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"339d7f3f-2a04-4f22-a8b4-6edfc5542884\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"127a8fa3-2cc0-42b6-8fc9-c95cb9ec0d4e\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"8e6fdec8-ec3a-4f29-8e2b-ef80051e49ee\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"a16b44af-52a5-40cb-b2d4-e8bb6337b0f7\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"9f75de5b-9887-4d1a-ad7f-d2d94fda4caa\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"20d742ae-c915-4be2-86ef-6fc82a861b25\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"704694a6-a0b3-4056-81ea-856541b9d429\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"70589a63-b534-4e8f-b6a7-dab7172c8684\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"cd1690fb-7dc4-4e39-9be5-809b59f105e3\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"22b3a3dc-c84f-4216-963d-2cf2857f6917\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"a5a1fad7-2ee3-44eb-b3ea-234516929442\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"10d90283-2135-47fc-8720-f8758dc35869\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"a9c2ef9b-9ed7-4476-bce8-66fccadae8cc\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"1f1a72b4-2e77-4494-87d8-a5d22203db79\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"fcf3c9a4-0edc-49a5-a12a-bf47dd668d6b\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"eab87407-c4c9-47ec-a1cf-bf8df61d0ea5\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"99d152c0-1456-4114-af75-f7885597b991\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"42b658f6-0b92-4e5f-8bc4-851f7573ea68\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"68f93ff5-5a89-41ae-b730-d8505bc7447b\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"873e0880-342d-4ed1-81fa-193fda3c5761\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"60ad307a-6927-4182-a58f-e477093d0e19\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"3886dd95-f552-4a1c-92b4-d7340e506271\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"d8680003-c3df-4a1e-be09-dece4e3888cf\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"4ca9b64f-7fed-46b4-88b8-c0c36455c0a0\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"9395162f-09ff-4600-bed2-27f60a69637d\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"63d059b1-b624-48c5-ac3b-b9d0e1e90a7c\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"075aae49-9cca-400e-940b-4b23e3ceb3ed\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"57b7e8ab-1a14-4958-ab1b-7ca565a07e58\" \u003e  volume:\u003ccapacity_bytes:32212254720 volume_id:\"8555826b-cbe2-472a-b44f-0055822b2492\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"1ad1a423-134c-4ff0-8940-52737f2f32d3\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"ebf42d97-86cd-4bdd-8441-4de882df9bf6\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"5ff2dfea-96f2-4143-be54-3be5271d1923\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"54c7d1af-616a-4e35-a61a-48c03086fc8f\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"1fd1a108-4576-4941-80c4-fcef5142685d\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"f0e22c4d-aed1-4fdf-992c-bdb524cba3a4\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"ed4e4ccc-8cb2-4160-8d5d-a9655b46641c\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"2ebfdacb-d63f-408f-85b8-68a365df653c\" \u003e  volume:\u003ccapacity_bytes:10737418240 volume_id:\"e5cd8627-a51f-4851-8212-146e9e4ad52c\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"91624637-556c-44b7-a046-c02af49f28b3\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"ad36d217-0699-41d6-8ee5-05819874b435\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"0ded5e63-d209-419e-a435-bee2de2b0370\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"cf84c248-cf02-47fa-aaab-f4fbf63a5383\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"d9c944a2-59d0-41b5-88d7-9123325277d7\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"ccedd8ff-eac7-4bb9-8ca6-e16588f3ff99\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"21b762b8-58b8-463a-960c-5a9c0c655987\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"99ad0496-c185-4905-a090-f4df87046d2a\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"a95ab512-9846-4c5f-9281-bcb66fe12e8a\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"e8653e60-46ae-447b-8686-c08efc6af250\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"5994d86e-0c9f-43c6-a32c-90a8827d6a60\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"305901d5-29ea-44b6-b4c6-f0c1478d347a\" \u003e  volume:\u003ccapacity_bytes:5368709120 volume_id:\"7d155a4e-a099-47e5-89cf-2be94a62b896\" \u003e  volume:\u003ccapacity_bytes:8589934592 volume_id:\"c1d0c737-20cd-412f-ab6c-428f1b6723dc\" \u003e  volume:\u003ccapacity_bytes:1073741824 volume_id:\"5d01ac6e-2aec-48ce-90c3-1250080046c1\" \u003e  volume:\u003ccapacity_bytes:3221225472 volume_id:\"3df688e8-cb69-4cef-944a-6400c816008a\" \u003e  volume:\u003ccapacity_bytes:2147483648 volume_id:\"0775e6e3-a4aa-416b-a7a3-616cdaf27eb9\" \u003e ], XXX_NoUnkeyedLiteral={}, XXX_sizecache=0","time":"2024-11-20T18:44:42.973962635Z"}
```