### PR TITLE
Fix Panics from BeforeServe during Boot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/container-storage-interface/spec v1.6.0
 	github.com/dell/csi-metadata-retriever v1.10.0
-	github.com/dell/csm-hbnfs v0.0.0-20250401143151-95f13808d5cc
+	github.com/dell/csm-hbnfs v0.0.0-20250410194517-57732dae75c7
 	github.com/dell/dell-csi-extensions/common v1.7.1-0.20250404130030-01c3966b4bf6
 	github.com/dell/dell-csi-extensions/podmon v1.7.1-0.20250404130030-01c3966b4bf6
 	github.com/dell/dell-csi-extensions/replication v1.10.2-0.20250404130030-01c3966b4bf6

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,10 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dell/csi-metadata-retriever v1.10.0 h1:OMzbwSJ+CMOTpf4WgcrSbT3j9Ve1txuLmYkfSTkRSBc=
 github.com/dell/csi-metadata-retriever v1.10.0/go.mod h1:ppgtPHlxaRNmNizU+TnxZLz8tNotTAwByZ/Lg32n660=
+github.com/dell/csm-hbnfs v0.0.0-20250401143151-95f13808d5cc h1:e3kmwRtopvfEHe2e4NqbXftkgYzLHWHL7amjSDVfWRU=
+github.com/dell/csm-hbnfs v0.0.0-20250401143151-95f13808d5cc/go.mod h1:s0wmTFb45ajEnWcdWA/n/rWbPSKiBE6P7gRIJG5bTv4=
+github.com/dell/csm-hbnfs v0.0.0-20250410194517-57732dae75c7 h1:biX0x/jymZLb/QLpZfdN0NXHlvi8zDPAbZQZStYpkNw=
+github.com/dell/csm-hbnfs v0.0.0-20250410194517-57732dae75c7/go.mod h1:s0wmTFb45ajEnWcdWA/n/rWbPSKiBE6P7gRIJG5bTv4=
 github.com/dell/dell-csi-extensions/common v1.7.1-0.20250404130030-01c3966b4bf6 h1:91iZVgQAziBR3AnfrfN/TOf7oMYSGDNoEwQlPc3PbP0=
 github.com/dell/dell-csi-extensions/common v1.7.1-0.20250404130030-01c3966b4bf6/go.mod h1:0cJvgNiPOosCJujd60aV9ZTujsHbRJNXX0ARRMDyjfw=
 github.com/dell/dell-csi-extensions/podmon v1.7.1-0.20250404130030-01c3966b4bf6 h1:Z1SGSuI2thsEpf9Zu7NXXyuQppYEEq3MdP37JQqt7cM=

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dell/csi-metadata-retriever v1.10.0 h1:OMzbwSJ+CMOTpf4WgcrSbT3j9Ve1txuLmYkfSTkRSBc=
 github.com/dell/csi-metadata-retriever v1.10.0/go.mod h1:ppgtPHlxaRNmNizU+TnxZLz8tNotTAwByZ/Lg32n660=
-github.com/dell/csm-hbnfs v0.0.0-20250401143151-95f13808d5cc h1:e3kmwRtopvfEHe2e4NqbXftkgYzLHWHL7amjSDVfWRU=
-github.com/dell/csm-hbnfs v0.0.0-20250401143151-95f13808d5cc/go.mod h1:s0wmTFb45ajEnWcdWA/n/rWbPSKiBE6P7gRIJG5bTv4=
 github.com/dell/dell-csi-extensions/common v1.7.1-0.20250404130030-01c3966b4bf6 h1:91iZVgQAziBR3AnfrfN/TOf7oMYSGDNoEwQlPc3PbP0=
 github.com/dell/dell-csi-extensions/common v1.7.1-0.20250404130030-01c3966b4bf6/go.mod h1:0cJvgNiPOosCJujd60aV9ZTujsHbRJNXX0ARRMDyjfw=
 github.com/dell/dell-csi-extensions/podmon v1.7.1-0.20250404130030-01c3966b4bf6 h1:Z1SGSuI2thsEpf9Zu7NXXyuQppYEEq3MdP37JQqt7cM=

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 	"syscall"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -164,13 +163,13 @@ func (s *service) UnmountVolume(ctx context.Context, volumeID, exportPath string
 
 	log.Infof("UnmountVolume calling Unmount %s", target)
 	err = sysUnmount(target, 0)
-	if err != nil && !strings.Contains(err.Error(), "no such file") {
+	if err != nil && !os.IsNotExist(err) {
 		log.Errorf("Could not Umount the target path: %s %s %s", volumeID, target, err.Error())
 		return err
 	}
 
 	err = osRemove(target)
-	if err != nil && !strings.Contains(err.Error(), "no such file") {
+	if err != nil && !os.IsNotExist(err) {
 		log.Errorf("UnmountVolume %s could not remove directory %s: %s", volumeID, target, err.Error())
 		return err
 	}
@@ -189,7 +188,7 @@ func (s *service) UnmountVolume(ctx context.Context, volumeID, exportPath string
 
 	// Remove the staging path.
 	err = osRemove(staging)
-	if err != nil && !strings.Contains(err.Error(), "no such file") {
+	if err != nil && !os.IsNotExist(err) {
 		log.Infof("UnmountVolume Remove %s staging path %s failed: %s", volumeID, "/noderoot/"+staging, err)
 	}
 	log.Infof("UnmountVolume %s ALL GOOD", volumeID)

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -164,13 +164,13 @@ func (s *service) UnmountVolume(ctx context.Context, volumeID, exportPath string
 
 	log.Infof("UnmountVolume calling Unmount %s", target)
 	err = sysUnmount(target, 0)
-	if err != nil && !strings.Contains(err.Error(), "No such file") {
-		log.Errorf("could not unmount the target path: %s %s %s", volumeID, target, err.Error())
+	if err != nil && !strings.Contains(err.Error(), "no such file") {
+		log.Errorf("Could not Umount the target path: %s %s %s", volumeID, target, err.Error())
 		return err
 	}
 
 	err = osRemove(target)
-	if err != nil && !strings.Contains(err.Error(), "No such file") {
+	if err != nil && !strings.Contains(err.Error(), "no such file") {
 		log.Errorf("UnmountVolume %s could not remove directory %s: %s", volumeID, target, err.Error())
 		return err
 	}
@@ -189,7 +189,7 @@ func (s *service) UnmountVolume(ctx context.Context, volumeID, exportPath string
 
 	// Remove the staging path.
 	err = osRemove(staging)
-	if err != nil && !strings.Contains(err.Error(), "No such file") {
+	if err != nil && !strings.Contains(err.Error(), "no such file") {
 		log.Infof("UnmountVolume Remove %s staging path %s failed: %s", volumeID, "/noderoot/"+staging, err)
 	}
 	log.Infof("UnmountVolume %s ALL GOOD", volumeID)


### PR DESCRIPTION
# Description
Return the error instead of performing a panic in the BeforeServe. This was causing misleading errors and CrashLoopBackOff for the controller Pod when the X_CSI_NODE_NAME is not present.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensure that unit tests pass.
- [x] Manually install PowerStore with Operator and ensure that the missing parameter no longer panics.
- [x] Ensure that Operator e2e tests pass accordingly.
