### PR TITLE
Support host-based NFS replication

### DIFF
--- a/pkg/array/array.go
+++ b/pkg/array/array.go
@@ -267,9 +267,6 @@ func GetPowerStoreArrays(fs fs.Interface, filePath string) (map[string]*PowerSto
 // VolumeHandle represents the components of a unique csi-powerstore volume identifier and any remote
 // volumes associated with the volume via data replication.
 type VolumeHandle struct {
-	// An optional prefix prepended to the volume handle; currently only used to denote an
-	// NFS volume for Host-Based NFS functionality.
-	Prefix string
 	// The UUID of a volume provisioned by a PowerStore system that is locally managed by this driver.
 	LocalUUID string
 	// The Global ID of the PowerStore system that is locally managed by this driver. The Global ID
@@ -284,14 +281,12 @@ type VolumeHandle struct {
 	Protocol string
 }
 
-// ParseVolumeID parses a volume id from the CO (Kubernetes) and tries to extract local and remote PowerStore volume UUID, Global ID, protocol,
-// any prefix that may exist.
+// ParseVolumeID parses a volume id from the CO (Kubernetes) and tries to extract local and remote PowerStore volume UUID, Global ID, and protocol.
 //
 // Example:
 //
 //	ParseVolumeID("1cd254s/192.168.0.1/scsi") assuming 192.168.0.1 is the IP array PSabc0123def will return
 //		VolumeHandle{
-//			Prefix: "",
 //			LocalUUID: "1cd254s",
 //			LocalArrayGlobalID: "PSabc0123def",
 //			RemoteUUID: "",
@@ -303,7 +298,6 @@ type VolumeHandle struct {
 //
 //	ParseVolumeID("9f840c56-96e6-4de9-b5a3-27e7c20eaa77/PSabcdef0123/scsi:9f840c56-96e6-4de9-b5a3-27e7c20eaa77/PS0123abcdef") returns
 //		VolumeHandle{
-//			Prefix: "",
 //			LocalUUID: "9f840c56-96e6-4de9-b5a3-27e7c20eaa77",
 //			LocalArrayGlobalID: "PSabcdef0123",
 //			RemoteUUID: "9f840c56-96e6-4de9-b5a3-27e7c20eaa77",
@@ -333,9 +327,6 @@ func ParseVolumeID(ctx context.Context, volumeHandleRaw string,
 	localVolumeHandle := strings.Split(volumeHandles[0], "/")
 	volumeHandle.LocalUUID = localVolumeHandle[0]
 	log.Debugf("ParseVolumeID: local volume handle: %s", localVolumeHandle)
-
-	// get the prefix, if any
-	volumeHandle.Prefix, volumeHandle.LocalUUID = GetVolumeIDPrefix(volumeHandle.LocalUUID)
 
 	if len(localVolumeHandle) == 1 {
 		// Legacy support where the volume name consists of only the volume ID.
@@ -390,8 +381,8 @@ func ParseVolumeID(ctx context.Context, volumeHandleRaw string,
 	}
 
 	log.Debugf(
-		"ParseVolumeID: prefix: %s, volumeID: %s, arrayID: %s, protocol: %s, remoteVolumeID: %s, remoteArrayID: %s",
-		volumeHandle.Prefix, volumeHandle.LocalUUID, volumeHandle.LocalArrayGlobalID, volumeHandle.Protocol, volumeHandle.RemoteUUID, volumeHandle.RemoteArrayGlobalID,
+		"ParseVolumeID: volumeID: %s, arrayID: %s, protocol: %s, remoteVolumeID: %s, remoteArrayID: %s",
+		volumeHandle.LocalUUID, volumeHandle.LocalArrayGlobalID, volumeHandle.Protocol, volumeHandle.RemoteUUID, volumeHandle.RemoteArrayGlobalID,
 	)
 	return volumeHandle, nil
 }

--- a/pkg/array/array.go
+++ b/pkg/array/array.go
@@ -395,12 +395,17 @@ func GetVolumeIDPrefix(ID string) (prefix, volumeID string) {
 	volumeID = ID
 	matchUUID := regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
 
-	// must run the check in case we're parsing a legacy volume ID
-	if matchUUID.FindString(volumeID) != "" {
-		i := matchUUID.FindStringIndex(volumeID)
-		prefix = volumeID[:i[0]]
-		volumeID = volumeID[i[0]:]
+	// if the ID does not contain a UUID, return as-is.
+	if matchUUID.FindString(volumeID) == "" {
+		return prefix, volumeID
 	}
+
+	// get the index of the UUID and use that to split the
+	// separate the volume UUID from any prefixes that may
+	// exist.
+	i := matchUUID.FindStringIndex(volumeID)
+	prefix = volumeID[:i[0]]
+	volumeID = volumeID[i[0]:]
 
 	return prefix, volumeID
 }

--- a/pkg/array/array.go
+++ b/pkg/array/array.go
@@ -398,7 +398,7 @@ func GetVolumeUUIDPrefix(volumeID string) (prefix string) {
 
 	// if the ID does not contain a UUID, return as-is.
 	if matchUUID.FindString(volumeID) == "" {
-		return prefix
+		return ""
 	}
 
 	// get the index of the UUID in the volumeID and use that

--- a/pkg/array/array_test.go
+++ b/pkg/array/array_test.go
@@ -259,7 +259,7 @@ func (s *LegacyParseVolumeTestSuite) TestVolumeCapabilityNFS() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), id, gotID.LocalUUID)
 	assert.Equal(s.T(), ip, gotID.LocalArrayGlobalID)
-	assert.Equal(s.T(), "nfs", gotID.TransportProtocol)
+	assert.Equal(s.T(), "nfs", gotID.Protocol)
 }
 
 func (s *LegacyParseVolumeTestSuite) TestVolumeCapabilitySCSI() {
@@ -285,7 +285,7 @@ func (s *LegacyParseVolumeTestSuite) TestVolumeCapabilitySCSI() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), id, gotID.LocalUUID)
 	assert.Equal(s.T(), validGlobalID, gotID.LocalArrayGlobalID)
-	assert.Equal(s.T(), scsi, gotID.TransportProtocol)
+	assert.Equal(s.T(), scsi, gotID.Protocol)
 }
 
 func (s *LegacyParseVolumeTestSuite) TestMissingSCSIProtocol() {
@@ -297,7 +297,7 @@ func (s *LegacyParseVolumeTestSuite) TestMissingSCSIProtocol() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), validBlockVolumeUUID, gotID.LocalUUID)
 	assert.Equal(s.T(), s.psArray.GlobalID, gotID.LocalArrayGlobalID)
-	assert.Equal(s.T(), scsi, gotID.TransportProtocol)
+	assert.Equal(s.T(), scsi, gotID.Protocol)
 }
 
 func (s *LegacyParseVolumeTestSuite) TestGetNFSProtocolFromAPIClient() {
@@ -311,7 +311,7 @@ func (s *LegacyParseVolumeTestSuite) TestGetNFSProtocolFromAPIClient() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), validFileSystemUUID, id.LocalUUID)
 	assert.Equal(s.T(), validGlobalID, id.LocalArrayGlobalID)
-	assert.Equal(s.T(), nfs, id.TransportProtocol)
+	assert.Equal(s.T(), nfs, id.Protocol)
 }
 
 func (s *LegacyParseVolumeTestSuite) TestVolumeNotFound() {
@@ -366,7 +366,7 @@ func (s *LegacyParseVolumeTestSuite) TestIPAsArrayID() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), validBlockVolumeUUID, id.LocalUUID)
 	assert.Equal(s.T(), validGlobalID, id.LocalArrayGlobalID)
-	assert.Equal(s.T(), scsi, id.TransportProtocol)
+	assert.Equal(s.T(), scsi, id.Protocol)
 }
 
 func TestParseVolumeID(t *testing.T) {
@@ -375,7 +375,7 @@ func TestParseVolumeID(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, validBlockVolumeUUID, id.LocalUUID)
 		assert.Equal(t, validGlobalID, id.LocalArrayGlobalID)
-		assert.Equal(t, scsi, id.TransportProtocol)
+		assert.Equal(t, scsi, id.Protocol)
 	})
 
 	t.Run("incorrect volume id", func(t *testing.T) {
@@ -390,7 +390,7 @@ func TestParseVolumeID(t *testing.T) {
 		assert.Equal(t, validRemoteBlockVolumeUUID, id.RemoteUUID)
 		assert.Equal(t, validGlobalID, id.LocalArrayGlobalID)
 		assert.Equal(t, validRemoteGlobalID, id.RemoteArrayGlobalID)
-		assert.Equal(t, scsi, id.TransportProtocol)
+		assert.Equal(t, scsi, id.Protocol)
 	})
 
 	localVolUUID := "aaaaaaaa-0000-bbbb-1111-cccccccccccc"
@@ -422,7 +422,7 @@ func TestParseVolumeID(t *testing.T) {
 				LocalArrayGlobalID:  powerstoreLocalSystemID,
 				RemoteUUID:          "",
 				RemoteArrayGlobalID: "",
-				TransportProtocol:   scsi,
+				Protocol:            scsi,
 			},
 			wantErr: false,
 		},

--- a/pkg/array/array_test.go
+++ b/pkg/array/array_test.go
@@ -419,7 +419,7 @@ func TestParseVolumeID(t *testing.T) {
 				vc:           nil,
 			},
 			want: array.VolumeHandle{
-				Prefix:              hbnfs.CsiNfsPrefix,
+				Prefix:              hbnfs.CsiNfsPrefixDash,
 				LocalUUID:           localVolUUID,
 				LocalArrayGlobalID:  powerstoreLocalSystemID,
 				RemoteUUID:          "",

--- a/pkg/array/array_test.go
+++ b/pkg/array/array_test.go
@@ -417,8 +417,7 @@ func TestParseVolumeID(t *testing.T) {
 				vc:           nil,
 			},
 			want: array.VolumeHandle{
-				Prefix:              hbnfs.CsiNfsPrefixDash,
-				LocalUUID:           localVolUUID,
+				LocalUUID:           hbnfs.CsiNfsPrefixDash + localVolUUID,
 				LocalArrayGlobalID:  powerstoreLocalSystemID,
 				RemoteUUID:          "",
 				RemoteArrayGlobalID: "",

--- a/pkg/array/array_test.go
+++ b/pkg/array/array_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -30,6 +31,7 @@ import (
 	"github.com/dell/csi-powerstore/v2/pkg/array"
 	"github.com/dell/csi-powerstore/v2/pkg/common"
 	"github.com/dell/csi-powerstore/v2/pkg/common/fs"
+	hbnfs "github.com/dell/csm-hbnfs/nfs"
 	"github.com/dell/gopowerstore"
 
 	"github.com/dell/gopowerstore/api"
@@ -255,11 +257,11 @@ func (s *LegacyParseVolumeTestSuite) TestVolumeCapabilityNFS() {
 	}
 
 	volCap := getVolCap()
-	gotID, gotIP, protocol, _, _, err := array.ParseVolumeID(context.Background(), id, &array.PowerStoreArray{IP: ip, GlobalID: "gid1"}, volCap)
+	gotID, err := array.ParseVolumeID(context.Background(), id, &array.PowerStoreArray{IP: ip, GlobalID: "gid1"}, volCap)
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), id, gotID)
-	assert.Equal(s.T(), ip, gotIP)
-	assert.Equal(s.T(), protocol, "nfs")
+	assert.Equal(s.T(), id, gotID.LocalUUID)
+	assert.Equal(s.T(), ip, gotID.LocalArrayGlobalID)
+	assert.Equal(s.T(), "nfs", gotID.TransportProtocol)
 }
 
 func (s *LegacyParseVolumeTestSuite) TestVolumeCapabilitySCSI() {
@@ -281,11 +283,11 @@ func (s *LegacyParseVolumeTestSuite) TestVolumeCapabilitySCSI() {
 	}
 
 	volCap := getVolCap()
-	gotID, gotGlobalID, protocol, _, _, err := array.ParseVolumeID(context.Background(), id, &array.PowerStoreArray{IP: ip, GlobalID: validGlobalID}, volCap)
+	gotID, err := array.ParseVolumeID(context.Background(), id, &array.PowerStoreArray{IP: ip, GlobalID: validGlobalID}, volCap)
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), id, gotID)
-	assert.Equal(s.T(), validGlobalID, gotGlobalID)
-	assert.Equal(s.T(), scsi, protocol)
+	assert.Equal(s.T(), id, gotID.LocalUUID)
+	assert.Equal(s.T(), validGlobalID, gotID.LocalArrayGlobalID)
+	assert.Equal(s.T(), scsi, gotID.TransportProtocol)
 }
 
 func (s *LegacyParseVolumeTestSuite) TestMissingSCSIProtocol() {
@@ -293,11 +295,11 @@ func (s *LegacyParseVolumeTestSuite) TestMissingSCSIProtocol() {
 	// if GetVolume returns without error, the protocol should be scsi.
 	s.mockAPI.GetVolume.Return(gopowerstore.Volume{ID: validBlockVolumeUUID}, nil)
 
-	id, globalID, protocol, _, _, err := array.ParseVolumeID(context.Background(), validBlockVolumeUUID, s.psArray, nil)
+	gotID, err := array.ParseVolumeID(context.Background(), validBlockVolumeUUID, s.psArray, nil)
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), validBlockVolumeUUID, id)
-	assert.Equal(s.T(), s.psArray.GlobalID, globalID)
-	assert.Equal(s.T(), protocol, scsi)
+	assert.Equal(s.T(), validBlockVolumeUUID, gotID.LocalUUID)
+	assert.Equal(s.T(), s.psArray.GlobalID, gotID.LocalArrayGlobalID)
+	assert.Equal(s.T(), scsi, gotID.TransportProtocol)
 }
 
 func (s *LegacyParseVolumeTestSuite) TestGetNFSProtocolFromAPIClient() {
@@ -307,11 +309,11 @@ func (s *LegacyParseVolumeTestSuite) TestGetNFSProtocolFromAPIClient() {
 	s.mockAPI.GetVolume.Return(gopowerstore.Volume{}, errors.New("error"))
 	s.mockAPI.GetFS.Return(gopowerstore.FileSystem{ID: validFileSystemUUID}, nil)
 
-	id, globalID, protocol, _, _, err := array.ParseVolumeID(context.Background(), validFileSystemUUID, s.psArray, nil)
+	id, err := array.ParseVolumeID(context.Background(), validFileSystemUUID, s.psArray, nil)
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), validFileSystemUUID, id)
-	assert.Equal(s.T(), validGlobalID, globalID)
-	assert.Equal(s.T(), protocol, nfs)
+	assert.Equal(s.T(), validFileSystemUUID, id.LocalUUID)
+	assert.Equal(s.T(), validGlobalID, id.LocalArrayGlobalID)
+	assert.Equal(s.T(), nfs, id.TransportProtocol)
 }
 
 func (s *LegacyParseVolumeTestSuite) TestVolumeNotFound() {
@@ -329,7 +331,7 @@ func (s *LegacyParseVolumeTestSuite) TestVolumeNotFound() {
 
 	s.mockAPI.GetFS.Return(gopowerstore.FileSystem{}, error(s.mockAPI.APIError))
 
-	_, _, _, _, _, err := array.ParseVolumeID(context.Background(), validFileSystemUUID, s.psArray, nil)
+	_, err := array.ParseVolumeID(context.Background(), validFileSystemUUID, s.psArray, nil)
 	assert.ErrorIs(s.T(), err, error(s.mockAPI.APIError))
 }
 
@@ -348,7 +350,7 @@ func (s *LegacyParseVolumeTestSuite) TestVolumeUnknownError() {
 
 	s.mockAPI.GetFS.Return(gopowerstore.FileSystem{}, error(s.mockAPI.APIError))
 
-	_, _, _, _, _, err := array.ParseVolumeID(context.Background(), validFileSystemUUID, s.psArray, nil)
+	_, err := array.ParseVolumeID(context.Background(), validFileSystemUUID, s.psArray, nil)
 	assert.ErrorContains(s.T(), err, s.mockAPI.APIError.ErrorMsg.Message)
 }
 
@@ -362,36 +364,83 @@ func (s *LegacyParseVolumeTestSuite) TestIPAsArrayID() {
 	// Build a volume ID using an IP in place of a PowerStore Global ID
 	volID := buildVolumeName(validBlockVolumeUUID, validPowerStoreIP, scsi)
 
-	id, globalID, protocol, _, _, err := array.ParseVolumeID(context.Background(), volID, nil, nil)
+	id, err := array.ParseVolumeID(context.Background(), volID, nil, nil)
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), validBlockVolumeUUID, id)
-	assert.Equal(s.T(), globalID, validGlobalID)
-	assert.Equal(s.T(), protocol, scsi)
+	assert.Equal(s.T(), validBlockVolumeUUID, id.LocalUUID)
+	assert.Equal(s.T(), validGlobalID, id.LocalArrayGlobalID)
+	assert.Equal(s.T(), scsi, id.TransportProtocol)
 }
 
 func TestParseVolumeID(t *testing.T) {
 	t.Run("parse volume name", func(t *testing.T) {
-		id, globalID, protocol, _, _, err := array.ParseVolumeID(context.Background(), validBlockVolumeNameSCSI, nil, nil)
+		id, err := array.ParseVolumeID(context.Background(), validBlockVolumeNameSCSI, nil, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, validBlockVolumeUUID, id)
-		assert.Equal(t, validGlobalID, globalID)
-		assert.Equal(t, scsi, protocol)
+		assert.Equal(t, validBlockVolumeUUID, id.LocalUUID)
+		assert.Equal(t, validGlobalID, id.LocalArrayGlobalID)
+		assert.Equal(t, scsi, id.TransportProtocol)
 	})
 
 	t.Run("incorrect volume id", func(t *testing.T) {
-		_, _, _, _, _, err := array.ParseVolumeID(context.Background(), "", nil, nil)
+		_, err := array.ParseVolumeID(context.Background(), "", nil, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("parse metro volume name", func(t *testing.T) {
-		id, globalID, protocol, remoteID, remoteGlobalID, err := array.ParseVolumeID(context.Background(), validMetroBlockVolumeNameSCSI, nil, nil)
+		id, err := array.ParseVolumeID(context.Background(), validMetroBlockVolumeNameSCSI, nil, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, validBlockVolumeUUID, id)
-		assert.Equal(t, validRemoteBlockVolumeUUID, remoteID)
-		assert.Equal(t, validGlobalID, globalID)
-		assert.Equal(t, remoteGlobalID, validRemoteGlobalID)
-		assert.Equal(t, scsi, protocol)
+		assert.Equal(t, validBlockVolumeUUID, id.LocalUUID)
+		assert.Equal(t, validRemoteBlockVolumeUUID, id.RemoteUUID)
+		assert.Equal(t, validGlobalID, id.LocalArrayGlobalID)
+		assert.Equal(t, validRemoteGlobalID, id.RemoteArrayGlobalID)
+		assert.Equal(t, scsi, id.TransportProtocol)
 	})
+
+	localVolUUID := "aaaaaaaa-0000-bbbb-1111-cccccccccccc"
+	powerstoreLocalSystemID := "PS000000000001"
+	HBNFSVolumeID := hbnfs.CsiNfsPrefixDash + localVolUUID + "/" + powerstoreLocalSystemID + "/" + scsi
+	type args struct {
+		ctx          context.Context
+		volumeHandle string
+		defaultArray *array.PowerStoreArray
+		vc           *csi.VolumeCapability
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    array.VolumeHandle
+		wantErr bool
+	}{
+		{
+			name: "parse volume handle for a host-based nfs volume",
+			args: args{
+				ctx:          context.Background(),
+				volumeHandle: HBNFSVolumeID,
+				defaultArray: nil,
+				vc:           nil,
+			},
+			want: array.VolumeHandle{
+				Prefix:              hbnfs.CsiNfsPrefix,
+				LocalUUID:           localVolUUID,
+				LocalArrayGlobalID:  powerstoreLocalSystemID,
+				RemoteUUID:          "",
+				RemoteArrayGlobalID: "",
+				TransportProtocol:   scsi,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := array.ParseVolumeID(tt.args.ctx, tt.args.volumeHandle, tt.args.defaultArray, tt.args.vc)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseVolumeID() got = %v, want %v", got, tt.want)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseVolumeID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
 }
 
 func TestLocker_UpdateArrays(t *testing.T) {

--- a/pkg/array/array_test.go
+++ b/pkg/array/array_test.go
@@ -468,44 +468,37 @@ func Test_getVolumeIDPrefix(t *testing.T) {
 		ID string
 	}
 	tests := []struct {
-		name         string
-		args         args
-		wantPrefix   string
-		wantVolumeID string
+		name       string
+		args       args
+		wantPrefix string
 	}{
 		{
 			name: "legacy volume ID",
 			args: args{
 				ID: legacyVolumeID,
 			},
-			wantPrefix:   "",
-			wantVolumeID: legacyVolumeID,
+			wantPrefix: "",
 		},
 		{
 			name: "volume UUID with no prefix",
 			args: args{
 				ID: validBlockVolumeUUID,
 			},
-			wantPrefix:   "",
-			wantVolumeID: validBlockVolumeUUID,
+			wantPrefix: "",
 		},
 		{
 			name: "volume UUID with host-based nfs prefix",
 			args: args{
 				ID: hbnfs.CsiNfsPrefixDash + validBlockVolumeUUID,
 			},
-			wantPrefix:   hbnfs.CsiNfsPrefixDash,
-			wantVolumeID: validBlockVolumeUUID,
+			wantPrefix: hbnfs.CsiNfsPrefixDash,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPrefix, gotVolumeID := array.GetVolumeIDPrefix(tt.args.ID)
+			gotPrefix := array.GetVolumeUUIDPrefix(tt.args.ID)
 			if gotPrefix != tt.wantPrefix {
 				t.Errorf("getVolumeIDPrefix() gotPrefix = %v, want %v", gotPrefix, tt.wantPrefix)
-			}
-			if gotVolumeID != tt.wantVolumeID {
-				t.Errorf("getVolumeIDPrefix() gotVolumeID = %v, want %v", gotVolumeID, tt.wantVolumeID)
 			}
 		})
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -222,15 +222,15 @@ func (s *Service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		volumeSource := contentSource.GetVolume()
 		if volumeSource != nil {
 			log.Printf("volume %s specified as volume content source", volumeSource.VolumeId)
-			parsedID, _, _, _, _, _ := array.ParseVolumeID(ctx, volumeSource.VolumeId, s.DefaultArray(), nil)
-			volumeSource.VolumeId = parsedID
+			volumeHandle, _ := array.ParseVolumeID(ctx, volumeSource.VolumeId, s.DefaultArray(), nil)
+			volumeSource.VolumeId = volumeHandle.LocalUUID
 			volResp, err = creator.Clone(ctx, volumeSource, req.GetName(), sizeInBytes, req.Parameters, arr.GetClient())
 		}
 		snapshotSource := contentSource.GetSnapshot()
 		if snapshotSource != nil {
 			log.Printf("snapshot %s specified as volume content source", snapshotSource.SnapshotId)
-			parsedID, _, _, _, _, _ := array.ParseVolumeID(ctx, snapshotSource.SnapshotId, s.DefaultArray(), nil)
-			snapshotSource.SnapshotId = parsedID
+			volumeHandle, _ := array.ParseVolumeID(ctx, snapshotSource.SnapshotId, s.DefaultArray(), nil)
+			snapshotSource.SnapshotId = volumeHandle.LocalUUID
 			volResp, err = creator.CreateVolumeFromSnapshot(ctx, snapshotSource,
 				req.GetName(), sizeInBytes, req.Parameters, arr.GetClient())
 		}
@@ -473,13 +473,18 @@ func (s *Service) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest
 		return nil, status.Error(codes.InvalidArgument, "volume ID is required")
 	}
 
-	id, arrayID, protocol, remoteVolumeID, _, err := array.ParseVolumeID(ctx, id, s.DefaultArray(), nil)
+	volumeHandle, err := array.ParseVolumeID(ctx, id, s.DefaultArray(), nil)
 	if err != nil {
 		if apiError, ok := err.(gopowerstore.APIError); ok && apiError.NotFound() {
 			return &csi.DeleteVolumeResponse{}, nil
 		}
 		return nil, err
 	}
+
+	id = volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	protocol := volumeHandle.TransportProtocol
+	remoteVolumeID := volumeHandle.RemoteUUID
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {
@@ -647,11 +652,18 @@ func (s *Service) ControllerPublishVolume(ctx context.Context, req *csi.Controll
 		return nil, status.Error(codes.InvalidArgument, "volume ID is required")
 	}
 
-	id, arrayID, protocol, remoteVolumeID, remoteArrayID, err := array.ParseVolumeID(ctx, id, s.DefaultArray(), req.VolumeCapability)
+	volumeHandle, err := array.ParseVolumeID(ctx, id, s.DefaultArray(), req.VolumeCapability)
 	if err != nil {
 		log.Error(err)
 		return nil, err
 	}
+
+	id = volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	protocol := volumeHandle.TransportProtocol
+	remoteVolumeID := volumeHandle.RemoteUUID
+	remoteArrayID := volumeHandle.RemoteArrayGlobalID
+
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to find array with ID %s", arrayID)
@@ -720,7 +732,7 @@ func (s *Service) ControllerUnpublishVolume(ctx context.Context, req *csi.Contro
 		return nil, status.Error(codes.InvalidArgument, "node ID is required")
 	}
 
-	id, arrayID, protocol, remoteVolumeID, remoteArrayID, err := array.ParseVolumeID(ctx, id, s.DefaultArray(), nil)
+	volumeHandle, err := array.ParseVolumeID(ctx, id, s.DefaultArray(), nil)
 	if err != nil {
 		if apiError, ok := err.(gopowerstore.APIError); ok && apiError.NotFound() {
 			return &csi.ControllerUnpublishVolumeResponse{}, nil
@@ -728,6 +740,12 @@ func (s *Service) ControllerUnpublishVolume(ctx context.Context, req *csi.Contro
 		return nil, status.Errorf(codes.Unknown,
 			"failure checking volume status for volume unpublishing: %s", err.Error())
 	}
+
+	id = volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	protocol := volumeHandle.TransportProtocol
+	remoteVolumeID := volumeHandle.RemoteUUID
+	remoteArrayID := volumeHandle.RemoteArrayGlobalID
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {
@@ -960,10 +978,15 @@ func (s *Service) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valid
 	}
 	// for sanity
 	id := req.GetVolumeId()
-	id, arrayID, proto, _, _, err := array.ParseVolumeID(ctx, id, s.DefaultArray(), nil)
+	volumeHandle, err := array.ParseVolumeID(ctx, id, s.DefaultArray(), nil)
 	if err != nil {
 		return &csi.ValidateVolumeCapabilitiesResponse{}, status.Error(codes.NotFound, "No such volume")
 	}
+
+	id = volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	proto := volumeHandle.TransportProtocol
+
 	if proto == "nfs" {
 		_, err := s.Arrays()[arrayID].Client.GetFS(ctx, id)
 		if err != nil {
@@ -1163,10 +1186,14 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotReq
 		return nil, status.Errorf(codes.InvalidArgument, "volume ID to be snapped is required")
 	}
 
-	id, arrayID, protocol, _, _, err := array.ParseVolumeID(ctx, sourceVolID, s.DefaultArray(), nil)
+	volumeHandle, err := array.ParseVolumeID(ctx, sourceVolID, s.DefaultArray(), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	id := volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	protocol := volumeHandle.TransportProtocol
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {
@@ -1236,13 +1263,17 @@ func (s *Service) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotReq
 		return nil, status.Errorf(codes.InvalidArgument, "snapshot ID to be deleted is required")
 	}
 
-	id, arrayID, protocol, _, _, err := array.ParseVolumeID(ctx, snapID, s.DefaultArray(), nil)
+	volumeHandle, err := array.ParseVolumeID(ctx, snapID, s.DefaultArray(), nil)
 	if err != nil {
 		if apiError, ok := err.(gopowerstore.APIError); ok && apiError.NotFound() {
 			return &csi.DeleteSnapshotResponse{}, nil
 		}
 		return nil, err
 	}
+
+	id := volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	protocol := volumeHandle.TransportProtocol
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {
@@ -1366,10 +1397,15 @@ func isPausedMetroSession(ctx context.Context, metroSessionID string, arr *array
 
 // ControllerExpandVolume resizes Volume or FileSystem by increasing available volume capacity in the storage array.
 func (s *Service) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	id, arrayID, protocol, remoteVolumeID, _, err := array.ParseVolumeID(ctx, req.VolumeId, s.DefaultArray(), nil)
+	volumeHandle, err := array.ParseVolumeID(ctx, req.VolumeId, s.DefaultArray(), nil)
 	if err != nil {
 		return nil, status.Errorf(codes.OutOfRange, "unable to parse the volume id")
 	}
+
+	id := volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	protocol := volumeHandle.TransportProtocol
+	remoteVolumeID := volumeHandle.RemoteUUID
 
 	requiredBytes := req.GetCapacityRange().GetRequiredBytes()
 	if requiredBytes > MaxVolumeSizeBytes {
@@ -1429,10 +1465,15 @@ func (s *Service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 
 // ControllerGetVolume fetch current information about a volume
 func (s *Service) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
-	id, arrayID, protocol, _, _, err := array.ParseVolumeID(ctx, req.VolumeId, s.DefaultArray(), nil)
+	volumeHandle, err := array.ParseVolumeID(ctx, req.VolumeId, s.DefaultArray(), nil)
 	if err != nil {
 		return nil, status.Errorf(codes.OutOfRange, "unable to parse the volume id")
 	}
+
+	id := volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	protocol := volumeHandle.TransportProtocol
+
 	var hosts []string
 	abnormal := false
 	message := ""
@@ -1596,11 +1637,15 @@ func (s *Service) listPowerStoreSnapshots(ctx context.Context, startToken, maxEn
 		}
 	} else if snapID != "" {
 		log.Infof("Requested snapshot via snapshot id %s", snapID)
-		id, arrayID, protocol, _, _, err := array.ParseVolumeID(ctx, snapID, s.DefaultArray(), nil)
+		volumeHandle, err := array.ParseVolumeID(ctx, snapID, s.DefaultArray(), nil)
 		if err != nil {
 			log.Error(err)
 			return []GeneralSnapshot{}, "", nil
 		}
+
+		id := volumeHandle.LocalUUID
+		arrayID := volumeHandle.LocalArrayGlobalID
+		protocol := volumeHandle.TransportProtocol
 
 		arr, ok := s.Arrays()[arrayID]
 		if !ok {
@@ -1636,11 +1681,15 @@ func (s *Service) listPowerStoreSnapshots(ctx context.Context, startToken, maxEn
 	} else {
 		log.Infof("Requested snapshot via source id %s", srcID)
 		// This works VGS on single default array, But for multiple array scenario this default array should be changed to dynamic array
-		id, arrayID, protocol, _, _, err := array.ParseVolumeID(ctx, srcID, s.DefaultArray(), nil)
+		volumeHandle, err := array.ParseVolumeID(ctx, srcID, s.DefaultArray(), nil)
 		if err != nil {
 			log.Error(err)
 			return []GeneralSnapshot{}, "", nil
 		}
+
+		id := volumeHandle.LocalUUID
+		arrayID := volumeHandle.LocalArrayGlobalID
+		protocol := volumeHandle.TransportProtocol
 
 		arr, ok := s.Arrays()[arrayID]
 		if !ok {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -483,7 +483,7 @@ func (s *Service) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest
 
 	id = volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 	remoteVolumeID := volumeHandle.RemoteUUID
 
 	arr, ok := s.Arrays()[arrayID]
@@ -660,7 +660,7 @@ func (s *Service) ControllerPublishVolume(ctx context.Context, req *csi.Controll
 
 	id = volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 	remoteVolumeID := volumeHandle.RemoteUUID
 	remoteArrayID := volumeHandle.RemoteArrayGlobalID
 
@@ -743,7 +743,7 @@ func (s *Service) ControllerUnpublishVolume(ctx context.Context, req *csi.Contro
 
 	id = volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 	remoteVolumeID := volumeHandle.RemoteUUID
 	remoteArrayID := volumeHandle.RemoteArrayGlobalID
 
@@ -985,7 +985,7 @@ func (s *Service) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valid
 
 	id = volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	proto := volumeHandle.TransportProtocol
+	proto := volumeHandle.Protocol
 
 	if proto == "nfs" {
 		_, err := s.Arrays()[arrayID].Client.GetFS(ctx, id)
@@ -1193,7 +1193,7 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotReq
 
 	id := volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {
@@ -1273,7 +1273,7 @@ func (s *Service) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotReq
 
 	id := volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {
@@ -1404,7 +1404,7 @@ func (s *Service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 
 	id := volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 	remoteVolumeID := volumeHandle.RemoteUUID
 
 	requiredBytes := req.GetCapacityRange().GetRequiredBytes()
@@ -1472,7 +1472,7 @@ func (s *Service) ControllerGetVolume(ctx context.Context, req *csi.ControllerGe
 
 	id := volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 
 	var hosts []string
 	abnormal := false
@@ -1645,7 +1645,7 @@ func (s *Service) listPowerStoreSnapshots(ctx context.Context, startToken, maxEn
 
 		id := volumeHandle.LocalUUID
 		arrayID := volumeHandle.LocalArrayGlobalID
-		protocol := volumeHandle.TransportProtocol
+		protocol := volumeHandle.Protocol
 
 		arr, ok := s.Arrays()[arrayID]
 		if !ok {
@@ -1689,7 +1689,7 @@ func (s *Service) listPowerStoreSnapshots(ctx context.Context, startToken, maxEn
 
 		id := volumeHandle.LocalUUID
 		arrayID := volumeHandle.LocalArrayGlobalID
-		protocol := volumeHandle.TransportProtocol
+		protocol := volumeHandle.Protocol
 
 		arr, ok := s.Arrays()[arrayID]
 		if !ok {

--- a/pkg/controller/csi_extension_server.go
+++ b/pkg/controller/csi_extension_server.go
@@ -203,7 +203,8 @@ func (s *Service) ValidateVolumeHostConnectivity(ctx context.Context, req *podmo
 		}
 		// for loop req.GetVolumeIds()
 		for _, volID := range req.GetVolumeIds() {
-			_, globalID, _, _, _, err := array.ParseVolumeID(ctx, volID, s.DefaultArray(), nil)
+			volumeHandle, err := array.ParseVolumeID(ctx, volID, s.DefaultArray(), nil)
+			globalID = volumeHandle.LocalArrayGlobalID
 			if err != nil || globalID == "" {
 				log.Errorf("unable to retrieve array's globalID after parsing volumeID")
 				globalIDs[s.DefaultArray().GlobalID] = true
@@ -227,7 +228,10 @@ func (s *Service) ValidateVolumeHostConnectivity(ctx context.Context, req *podmo
 		if len(req.GetVolumeIds()) > 0 {
 			// Get array config
 			for _, volID := range req.GetVolumeIds() {
-				id, globalIDForVol, protocol, _, _, _ := array.ParseVolumeID(ctx, volID, s.DefaultArray(), nil)
+				volumeHandle, _ := array.ParseVolumeID(ctx, volID, s.DefaultArray(), nil)
+				id := volumeHandle.LocalUUID
+				globalIDForVol := volumeHandle.LocalArrayGlobalID
+				protocol := volumeHandle.TransportProtocol
 				if globalIDForVol != globalID {
 					log.Errorf("Recived globalId from podman is %s and retrieved from array is %s ", globalID, globalIDForVol)
 					return nil, fmt.Errorf("invalid globalId %s is provided", globalID)

--- a/pkg/controller/csi_extension_server.go
+++ b/pkg/controller/csi_extension_server.go
@@ -231,7 +231,7 @@ func (s *Service) ValidateVolumeHostConnectivity(ctx context.Context, req *podmo
 				volumeHandle, _ := array.ParseVolumeID(ctx, volID, s.DefaultArray(), nil)
 				id := volumeHandle.LocalUUID
 				globalIDForVol := volumeHandle.LocalArrayGlobalID
-				protocol := volumeHandle.TransportProtocol
+				protocol := volumeHandle.Protocol
 				if globalIDForVol != globalID {
 					log.Errorf("Recived globalId from podman is %s and retrieved from array is %s ", globalID, globalIDForVol)
 					return nil, fmt.Errorf("invalid globalId %s is provided", globalID)

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -50,7 +50,7 @@ func (s *Service) CreateRemoteVolume(ctx context.Context,
 	protocol := volumeHandle.Protocol
 
 	volPrefix := ""
-	if _, ok := params[nfs.CsiNfsParameter]; ok {
+	if accessMode, ok := params[nfs.CsiNfsParameter]; ok && accessMode != "" {
 		// host-based nfs volumes should have the "csi-nfs" parameter
 		// and an "nfs-" prefix in the volume ID that we need to remove
 		// for gopowerstore queries to succeed.
@@ -139,7 +139,7 @@ func (s *Service) CreateStorageProtectionGroup(ctx context.Context,
 	arrayID := volumeHandle.LocalArrayGlobalID
 	protocol := volumeHandle.Protocol
 
-	if _, ok := params[nfs.CsiNfsParameter]; ok {
+	if accessMode, ok := params[nfs.CsiNfsParameter]; ok && accessMode != "" {
 		// host-based nfs volumes should have the "csi-nfs" parameter
 		// and a "nfs-" prefix in the volume ID that we need to remove
 		// for gopowerstore queries to succeed

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -96,7 +96,10 @@ func (s *Service) CreateRemoteVolume(ctx context.Context,
 		s.replicationContextPrefix + "arrayID":           remoteSystem.SerialNumber,
 		s.replicationContextPrefix + "managementAddress": remoteSystem.ManagementAddress,
 	}
-	remoteVolume := getRemoteCSIVolume(remoteVolumeID+"/"+remoteParams[s.replicationContextPrefix+"arrayID"]+"/"+protocol, vol.Size)
+	remoteVolume := getRemoteCSIVolume(
+		volumeHandle.Prefix+remoteVolumeID+"/"+remoteParams[s.replicationContextPrefix+"arrayID"]+"/"+protocol,
+		vol.Size,
+	)
 	remoteVolume.VolumeContext = remoteParams
 	return &csiext.CreateRemoteVolumeResponse{
 		RemoteVolume: remoteVolume,

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -52,10 +52,11 @@ func (s *Service) CreateRemoteVolume(ctx context.Context,
 	volPrefix := ""
 	if _, ok := params[nfs.CsiNfsParameter]; ok {
 		// host-based nfs volumes should have the "csi-nfs" parameter
-		// and a "nfs-" prefix in the volume ID that we need to remove
+		// and an "nfs-" prefix in the volume ID that we need to remove
 		// for gopowerstore queries to succeed.
-		// Remove the prefix here and restore when building the response.
-		volPrefix, id = array.GetVolumeIDPrefix(id)
+		// Remove the prefix here and restore it when building the volume ID
+		// for the function response.
+		volPrefix = array.GetVolumeUUIDPrefix(id)
 		id = strings.TrimPrefix(id, volPrefix)
 	}
 
@@ -138,12 +139,11 @@ func (s *Service) CreateStorageProtectionGroup(ctx context.Context,
 	arrayID := volumeHandle.LocalArrayGlobalID
 	protocol := volumeHandle.Protocol
 
-	volPrefix := ""
 	if _, ok := params[nfs.CsiNfsParameter]; ok {
 		// host-based nfs volumes should have the "csi-nfs" parameter
 		// and a "nfs-" prefix in the volume ID that we need to remove
 		// for gopowerstore queries to succeed
-		volPrefix, id = array.GetVolumeIDPrefix(id)
+		volPrefix := array.GetVolumeUUIDPrefix(id)
 		id = strings.TrimPrefix(id, volPrefix)
 	}
 

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -45,7 +45,7 @@ func (s *Service) CreateRemoteVolume(ctx context.Context,
 	}
 	id := volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {
@@ -123,7 +123,7 @@ func (s *Service) CreateStorageProtectionGroup(ctx context.Context,
 
 	id := volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {

--- a/pkg/controller/replication.go
+++ b/pkg/controller/replication.go
@@ -38,11 +38,14 @@ func (s *Service) CreateRemoteVolume(ctx context.Context,
 		return nil, status.Error(codes.InvalidArgument, "volume ID is required")
 	}
 
-	id, arrayID, protocol, _, _, err := array.ParseVolumeID(ctx, volID, s.DefaultArray(), nil)
+	volumeHandle, err := array.ParseVolumeID(ctx, volID, s.DefaultArray(), nil)
 	if err != nil {
 		log.Error(err)
 		return nil, err
 	}
+	id := volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	protocol := volumeHandle.TransportProtocol
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {
@@ -109,11 +112,15 @@ func (s *Service) CreateStorageProtectionGroup(ctx context.Context,
 		return nil, status.Error(codes.InvalidArgument, "volume ID is required")
 	}
 
-	id, arrayID, protocol, _, _, err := array.ParseVolumeID(ctx, volID, s.DefaultArray(), nil)
+	volumeHandle, err := array.ParseVolumeID(ctx, volID, s.DefaultArray(), nil)
 	if err != nil {
 		log.Error(err)
 		return nil, err
 	}
+
+	id := volumeHandle.LocalUUID
+	arrayID := volumeHandle.LocalArrayGlobalID
+	protocol := volumeHandle.TransportProtocol
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {

--- a/pkg/controller/replication_test.go
+++ b/pkg/controller/replication_test.go
@@ -1196,6 +1196,9 @@ func TestService_CreateRemoteVolume(t *testing.T) {
 				context.Background(),
 				&csiext.CreateRemoteVolumeRequest{
 					VolumeHandle: localVolumeID,
+					Parameters: map[string]string{
+						nfs.CsiNfsParameter: "RWX",
+					},
 				},
 			},
 			before: func(s *Service) {

--- a/pkg/controller/replication_test.go
+++ b/pkg/controller/replication_test.go
@@ -19,11 +19,17 @@ package controller
 import (
 	"context"
 	"net/http"
+	"reflect"
+	"testing"
 
 	"github.com/dell/csi-powerstore/v2/pkg/array"
+	"github.com/dell/csi-powerstore/v2/pkg/common"
+	"github.com/dell/csi-powerstore/v2/pkg/common/fs"
+	"github.com/dell/csm-hbnfs/nfs"
 	csiext "github.com/dell/dell-csi-extensions/replication"
 	"github.com/dell/gopowerstore"
 	"github.com/dell/gopowerstore/api"
+	gopowerstoreMock "github.com/dell/gopowerstore/mocks"
 	ginkgo "github.com/onsi/ginkgo"
 	gomega "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
@@ -1126,3 +1132,161 @@ var _ = ginkgo.Describe("Replication", func() {
 		})
 	})
 })
+
+func TestService_CreateRemoteVolume(t *testing.T) {
+	const GiB int64 = 1073741824
+
+	replicationContextPrefix := "powerstore/"
+
+	localVolUUID := "aaaaaaaa-0000-bbbb-1111-cccccccccccc"
+	remoteVolUUID := "00000000-aaaa-1111-bbbb-222222222222"
+
+	powerstoreLocalSystemID := "PS000000000001"
+	powerstoreRemoteSystemID := "PS000000000001"
+
+	localVolumeID := nfs.CsiNfsPrefixDash + localVolUUID + "/" + powerstoreLocalSystemID + "/scsi"
+	remoteVolumeID := nfs.CsiNfsPrefixDash + remoteVolUUID + "/" + powerstoreRemoteSystemID + "/scsi"
+
+	powerstoreLocalSystemName := "local-system"
+
+	powerstoreLocalEndpoint := "127.0.0.1"
+	powerstoreRemoteEndpoint := "127.0.0.2"
+
+	powerstoreDefaultGID := powerstoreLocalSystemID
+
+	sourceArray := array.PowerStoreArray{
+		Endpoint:      powerstoreLocalEndpoint,
+		GlobalID:      powerstoreDefaultGID,
+		Username:      "user",
+		Password:      "password",
+		BlockProtocol: common.ISCSITransport,
+		Insecure:      true,
+		IsDefault:     true,
+		Client:        nil,
+	}
+
+	type fields struct {
+		Fs                          fs.Interface
+		externalAccess              string
+		nfsAcls                     string
+		replicationContextPrefix    string
+		replicationPrefix           string
+		isHealthMonitorEnabled      bool
+		isAutoRoundOffFsSizeEnabled bool
+	}
+	type args struct {
+		ctx context.Context
+		req *csiext.CreateRemoteVolumeRequest
+	}
+	type testcase struct {
+		name    string
+		fields  fields
+		args    args
+		before  func(s *Service)
+		want    *csiext.CreateRemoteVolumeResponse
+		wantErr bool
+	}
+	tests := []testcase{
+		{
+			name: "creates a remote host-based nfs volume",
+			fields: fields{
+				replicationContextPrefix: replicationContextPrefix,
+			},
+			args: args{
+				context.Background(),
+				&csiext.CreateRemoteVolumeRequest{
+					VolumeHandle: localVolumeID,
+				},
+			},
+			before: func(s *Service) {
+				// need to initialize the arrays and default array here,
+				// because we cannot copy the mutexs in array.Locker,
+				// and members of array.Locker are unexported, so we must
+				// use the provided setter funcs.
+
+				// make a copy so as not to modify the stub
+				defaultArray := sourceArray
+
+				// setup mock responses to gopowerstore queries
+				mockGopowerstoreClient := gopowerstoreMock.NewClient(t)
+				mockGopowerstoreClient.On("GetVolumeGroupsByVolumeID", mock.Anything, localVolUUID).Return(gopowerstore.VolumeGroups{
+					VolumeGroup: []gopowerstore.VolumeGroup{{ID: "vg-uuid"}},
+				}, nil)
+				mockGopowerstoreClient.On("GetReplicationSessionByLocalResourceID", mock.Anything, "vg-uuid").Return(
+					gopowerstore.ReplicationSession{
+						// return a replication session linking the volumes on local and remote systems
+						StorageElementPairs: []gopowerstore.StorageElementPair{
+							{
+								LocalStorageElementID:  localVolUUID,
+								RemoteStorageElementID: remoteVolUUID,
+							},
+						},
+						RemoteSystemID: powerstoreRemoteSystemID,
+					},
+					nil,
+				)
+				mockGopowerstoreClient.On("GetVolume", mock.Anything, localVolUUID).Return(
+					gopowerstore.Volume{
+						// only the size is required for this test. extra info is omitted.
+						Size: 5 * GiB,
+					}, nil,
+				)
+				mockGopowerstoreClient.On("GetCluster", mock.Anything).Return(gopowerstore.Cluster{Name: powerstoreLocalSystemName}, nil)
+				mockGopowerstoreClient.On("GetRemoteSystem", mock.Anything, powerstoreRemoteSystemID).Return(
+					gopowerstore.RemoteSystem{
+						SerialNumber:      powerstoreRemoteSystemID,
+						ManagementAddress: powerstoreRemoteEndpoint,
+					},
+					nil,
+				)
+
+				// assign the ephemeral mock client to the default array
+				defaultArray.Client = mockGopowerstoreClient
+				// add the default array to the list of arrays
+				arrays := map[string]*array.PowerStoreArray{
+					powerstoreDefaultGID: &defaultArray,
+				}
+
+				// initialize the Locker/arrays
+				s.Locker.SetArrays(arrays)
+				s.Locker.SetDefaultArray(&defaultArray)
+			},
+			want: &csiext.CreateRemoteVolumeResponse{
+				RemoteVolume: &csiext.Volume{
+					CapacityBytes: 5 * GiB,
+					VolumeId:      remoteVolumeID,
+					VolumeContext: map[string]string{
+						"remoteSystem":                                 powerstoreLocalSystemName,
+						replicationContextPrefix + "arrayID":           powerstoreRemoteSystemID,
+						replicationContextPrefix + "managementAddress": powerstoreRemoteEndpoint,
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				Fs:                          tt.fields.Fs,
+				externalAccess:              tt.fields.externalAccess,
+				nfsAcls:                     tt.fields.nfsAcls,
+				Locker:                      *new(array.Locker),
+				replicationContextPrefix:    tt.fields.replicationContextPrefix,
+				replicationPrefix:           tt.fields.replicationPrefix,
+				isHealthMonitorEnabled:      tt.fields.isHealthMonitorEnabled,
+				isAutoRoundOffFsSizeEnabled: tt.fields.isAutoRoundOffFsSizeEnabled,
+			}
+			tt.before(s)
+
+			got, err := s.CreateRemoteVolume(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Service.CreateRemoteVolume() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Service.CreateRemoteVolume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/replication_test.go
+++ b/pkg/controller/replication_test.go
@@ -1142,7 +1142,7 @@ func TestService_CreateRemoteVolume(t *testing.T) {
 	remoteVolUUID := "00000000-aaaa-1111-bbbb-222222222222"
 
 	powerstoreLocalSystemID := "PS000000000001"
-	powerstoreRemoteSystemID := "PS000000000001"
+	powerstoreRemoteSystemID := "PS000000000002"
 
 	localVolumeID := nfs.CsiNfsPrefixDash + localVolUUID + "/" + powerstoreLocalSystemID + "/scsi"
 	remoteVolumeID := nfs.CsiNfsPrefixDash + remoteVolUUID + "/" + powerstoreRemoteSystemID + "/scsi"

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -303,7 +303,7 @@ func (s *Service) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeR
 
 	id = volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 	remoteVolumeID := volumeHandle.RemoteUUID
 
 	arr, ok := s.Arrays()[arrayID]
@@ -368,7 +368,7 @@ func (s *Service) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVol
 	}
 	id = volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 	remoteVolumeID := volumeHandle.RemoteUUID
 
 	arr, ok := s.Arrays()[arrayID]
@@ -546,7 +546,7 @@ func (s *Service) NodePublishVolume(ctx context.Context, req *csi.NodePublishVol
 
 	volumeHandle, _ := array.ParseVolumeID(ctx, id, s.DefaultArray(), req.VolumeCapability)
 	id = volumeHandle.LocalUUID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 
 	stagingPath := req.GetStagingTargetPath()
 
@@ -668,7 +668,7 @@ func (s *Service) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolume
 	}
 	id := volumeHandle.LocalUUID
 	arrayID := volumeHandle.LocalArrayGlobalID
-	protocol := volumeHandle.TransportProtocol
+	protocol := volumeHandle.Protocol
 
 	arr, ok := s.Arrays()[arrayID]
 	if !ok {


### PR DESCRIPTION
# Description
These changes bring csi-powerstore host-based NFS volumes into scope for replication via csm-replication.  
Main changes are in pkg/controller/replication.go. 

Other changes include:
- Refactoring the volume handle parsing function to return a single `VolumeHandle` struct with members defining the different parts of the volume handle.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation -- **waiting on official feature name**
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- cert-csi certify for host-based nfs
- cert-csi certify for native nfs
- cert-csi certify for iscsi block
- cert-csi certify for iscsi metro
- replication e2e
```yaml
storageClasses:
  - name: powerstore-iscsi
    minSize: 5Gi
    rawBlock: true
    expansion: true
    clone: true
    snapshot: true
    RWX: false
    RWOP: true
    ephemeral:
      driver: csi-powerstore.dellemc.com
      fstype: ext4
      volumeAttributes:
        arrayID: "<arrayid>"
        protocol: iSCSI
        size: 5Gi
  - name: powerstore-nfs
    minSize: 5Gi
    rawBlock: false
    expansion: true
    clone: true
    snapshot: true
    RWX: true
    RWOP: false
    ephemeral:
      driver: csi-powerstore.dellemc.com
      fstype: "nfs"
      volumeAttributes:
        arrayID: "<arrayid>"
        protocol: NFS
        size: 5Gi
        nasName: "<nas-name>"
  - name: powerstore-metro-ext4
    minSize: 5Gi
    rawBlock: true
    expansion: false
    clone: false
    snapshot: false
    RWX: false
    RWOP: true
  - name: powerstore-hbnfs
    minSize: 5Gi
    rawBlock: false
    expansion: true
    clone: false
    snapshot: true
    RWX: false
    RWOP: true
    ephemeral:
      driver: csi-powerstore.dellemc.com
      fstype: "nfs"
      volumeAttributes:
        arrayID: "<arrayid>"
        protocol: NFS
        size: 5Gi
```