### PR TITLE
support cloning host-based nfs volumes

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -21,7 +21,6 @@ package service
 
 import (
 	"context"
-	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/dell/csm-hbnfs/nfs"
@@ -76,7 +75,7 @@ func removeNFSPrefixFromSourceID(source *csi.VolumeContentSource) error {
 			return status.Error(codes.InvalidArgument,
 				"the volume ID of the volume to be cloned cannot be empty")
 		}
-		if !strings.HasPrefix(volume.VolumeId, nfs.CsiNfsPrefixDash) {
+		if !nfs.IsNFSVolumeID(volume.VolumeId) {
 			return status.Error(codes.InvalidArgument,
 				"the volume ID of the volume to be cloned must be of the host-based NFS type")
 		}

--- a/pkg/service/controller_test.go
+++ b/pkg/service/controller_test.go
@@ -121,7 +121,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				},
 			},
-			mockSetup: func(mockController *mocks.ControllerInterface, _ *mocks.MockInterface, mockNfs *nfsmock.MockService) {
+			mockSetup: func(_ *mocks.ControllerInterface, _ *mocks.MockInterface, _ *nfsmock.MockService) {
 			},
 			expectedErr: status.Error(codes.InvalidArgument,
 				"the volume ID of the volume to be cloned must be of the host-based NFS type"),


### PR DESCRIPTION
# Description
Requests to `CreateVolume()` with another host-based NFS volume as the content source (a clone operation) would have a source volume ID containing the "nfs-" prefix. That volume ID would be passed to the driver for volume provisioning, and because the prefix is not parsed and removed, the driver will submit volume queries to the PowerStore API with volume UUIDs in the form of "nfs-<volume-UUID>" causing the requests to return errors, because of the malformed volume UUID.

For host-based NFS volume clone operations, these changes will confirm the volume source is another host-based NFS volume by checking for and removing the "nfs-" prefix before submitting any requests to the PowerStore API.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- cert-csi certify for iscsi block

```bash
$ cert-csi certify --cert-config=.../cert-csi-config.yaml --vsc powerstore-snapshot
[2025-04-17 14:39:42]  INFO Starting cert-csi; ver. 1.6.0
[2025-04-17 14:39:42]  INFO Suites to run with powerstore-iscsi storage class:
[2025-04-17 14:39:42]  INFO 1. VolumeIoSuite {volumes: 2, volumeSize: 5Gi chains: 2-2}
[2025-04-17 14:39:42]  INFO 2. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 5Gi}
[2025-04-17 14:39:42]  INFO 3. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 5Gi}
[2025-04-17 14:39:42]  INFO 4. VolumeExpansionSuite {pods: 1, volumes: 1, size: 5Gi, expSize: 10Gi, block: false}
[2025-04-17 14:39:42]  INFO 5. VolumeExpansionSuite {pods: 1, volumes: 1, size: 5Gi, expSize: 10Gi, block: true}
[2025-04-17 14:39:42]  INFO 6. SnapSuite {snapshots: 3, volumeSize; 5Gi}
[2025-04-17 14:39:42]  INFO 7. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 5Gi}
[2025-04-17 14:39:42]  INFO 8. MultiAttachSuite {pods: 5, rawBlock: true, size: 5Gi, accMode: ReadWriteMany}
[2025-04-17 14:39:42]  INFO 9. MultiAttachSuite {pods: 5, rawBlock: false, size: 5Gi, accMode: ReadWriteOncePod}
[2025-04-17 14:39:42]  INFO 10. EphemeralVolumeSuite {driver: csi-powerstore.dellemc.com, podNumber: 2, volAttributes: map[arrayid:<redacted> protocol:iSCSI size:5Gi]}
...
[2025-04-17 14:46:29]  INFO During this run 100.0% of suites succeeded
```
- cert-csi certify for host-based NFS

```bash
$ cert-csi certify --cert-config=.../cert-csi-config.yaml --vsc powerstore-snapshot
[2025-04-17 14:12:09]  INFO Starting cert-csi; ver. 1.6.0
[2025-04-17 14:12:09]  INFO Suites to run with powerstore-hbnfs storage class:
[2025-04-17 14:12:09]  INFO 1. VolumeIoSuite {volumes: 2, volumeSize: 5Gi chains: 2-2}
[2025-04-17 14:12:09]  INFO 2. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 5Gi}
[2025-04-17 14:12:09]  INFO 3. VolumeExpansionSuite {pods: 1, volumes: 1, size: 5Gi, expSize: 10Gi, block: false}
[2025-04-17 14:12:09]  INFO 4. SnapSuite {snapshots: 3, volumeSize; 5Gi}
[2025-04-17 14:12:09]  INFO 5. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 5Gi}
[2025-04-17 14:12:09]  INFO 6. MultiAttachSuite {pods: 5, rawBlock: false, size: 5Gi, accMode: ReadWriteMany}
[2025-04-17 14:12:09]  INFO 7. MultiAttachSuite {pods: 5, rawBlock: false, size: 5Gi, accMode: ReadWriteOncePod}
[2025-04-17 14:12:09]  INFO 8. EphemeralVolumeSuite {driver: csi-powerstore.dellemc.com, podNumber: 2, volAttributes: map[arrayid:<redacted> protocol:NFS size:5Gi]}
...
[2025-04-17 14:19:51]  INFO During this run 100.0% of suites succeeded
```

- cert-csi certify for PowerStore native NFS

```bash
$ cert-csi certify --cert-config=.../cert-csi-config.yaml --vsc powerstore-snapshot
[2025-04-17 14:51:07]  INFO Starting cert-csi; ver. 1.6.0
[2025-04-17 14:51:07]  INFO Suites to run with powerstore-nfs storage class:
[2025-04-17 14:51:07]  INFO 1. VolumeIoSuite {volumes: 2, volumeSize: 5Gi chains: 2-2}
[2025-04-17 14:51:07]  INFO 2. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 5Gi}
[2025-04-17 14:51:07]  INFO 3. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 5Gi}
[2025-04-17 14:51:07]  INFO 4. VolumeExpansionSuite {pods: 1, volumes: 1, size: 5Gi, expSize: 10Gi, block: false}
[2025-04-17 14:51:07]  INFO 5. SnapSuite {snapshots: 3, volumeSize; 5Gi}
[2025-04-17 14:51:07]  INFO 6. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 5Gi}
[2025-04-17 14:51:07]  INFO 7. MultiAttachSuite {pods: 5, rawBlock: false, size: 5Gi, accMode: ReadWriteMany}
[2025-04-17 14:51:07]  INFO 8. EphemeralVolumeSuite {driver: csi-powerstore.dellemc.com, podNumber: 2, volAttributes: map[arrayid:<redacted> nasname:<redacted> protocol:NFS size:5Gi]}
...
[2025-04-17 15:01:06]  INFO During this run 100.0% of suites succeeded
```