### PR TITLE
Fix: Unmounting HBNFS Volume

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/container-storage-interface/spec v1.6.0
 	github.com/dell/csi-metadata-retriever v1.10.0
-	github.com/dell/csm-hbnfs v0.0.0-20250428180458-f8a6d9ecb8c2
+	github.com/dell/csm-hbnfs v0.0.0-20250501141233-570087c187f5
 	github.com/dell/dell-csi-extensions/common v1.7.1-0.20250417144221-6fcddedebf59
 	github.com/dell/dell-csi-extensions/podmon v1.7.1-0.20250417144221-6fcddedebf59
 	github.com/dell/dell-csi-extensions/replication v1.10.2-0.20250417144221-6fcddedebf59

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dell/csi-metadata-retriever v1.10.0 h1:OMzbwSJ+CMOTpf4WgcrSbT3j9Ve1txuLmYkfSTkRSBc=
 github.com/dell/csi-metadata-retriever v1.10.0/go.mod h1:ppgtPHlxaRNmNizU+TnxZLz8tNotTAwByZ/Lg32n660=
-github.com/dell/csm-hbnfs v0.0.0-20250428180458-f8a6d9ecb8c2 h1:29PgwImmlKmzZZO+j0o+qI8vZ9i1PdslgpD9xszI/MM=
-github.com/dell/csm-hbnfs v0.0.0-20250428180458-f8a6d9ecb8c2/go.mod h1:s0wmTFb45ajEnWcdWA/n/rWbPSKiBE6P7gRIJG5bTv4=
+github.com/dell/csm-hbnfs v0.0.0-20250501141233-570087c187f5 h1:ox1w+v+UnevCfRfimVeCdEzwK/1l95zapW+uOSUjKVI=
+github.com/dell/csm-hbnfs v0.0.0-20250501141233-570087c187f5/go.mod h1:s0wmTFb45ajEnWcdWA/n/rWbPSKiBE6P7gRIJG5bTv4=
 github.com/dell/dell-csi-extensions/common v1.7.1-0.20250417144221-6fcddedebf59 h1:XFwQVs0xU5qnRdjeY3YrWx6s33FW5lJ0tbXf6xUplfw=
 github.com/dell/dell-csi-extensions/common v1.7.1-0.20250417144221-6fcddedebf59/go.mod h1:0cJvgNiPOosCJujd60aV9ZTujsHbRJNXX0ARRMDyjfw=
 github.com/dell/dell-csi-extensions/podmon v1.7.1-0.20250417144221-6fcddedebf59 h1:+AdjYW32ofGgCWXleGSSw/qvw1ECLXXZl2ZV458Gc0w=

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	osRemove   = os.Remove
+	osRemove   = os.RemoveAll
 	sysUnmount = syscall.Unmount
 )
 

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -70,7 +70,7 @@ func (s *service) NodePublishVolume(ctx context.Context, req *csi.NodePublishVol
 func (s *service) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	if nfs.IsNFSVolumeID(req.GetVolumeId()) {
 		log.Infof("[FERNANDO] csi-nfs: RWX calling nfssvc.NodeUnpublishVolume")
-		// return nfssvc.NodeUnpublishVolume(ctx, req)
+		return nfssvc.NodeUnpublishVolume(ctx, req)
 	}
 
 	return nodeSvc.NodeUnpublishVolume(ctx, req)

--- a/pkg/service/node_test.go
+++ b/pkg/service/node_test.go
@@ -257,15 +257,13 @@ func TestMountVolume(t *testing.T) {
 
 func TestUnmountVolume(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	utilMock := new(mocks.UtilInterface)
-	fsMock := new(mocks.FsInterface)
 	defer ctrl.Finish()
-	svc := service{
-		fs: fsMock,
-	}
 	ctx := context.Background()
 
 	t.Run("Umount fail", func(t *testing.T) {
+		utilMock := new(mocks.UtilInterface)
+		fsMock := new(mocks.FsInterface)
+
 		defaultSysUnmount := sysUnmount
 		sysUnmount = func(_ string, _ int) error {
 			return errors.New("operation not permitted")
@@ -281,6 +279,10 @@ func TestUnmountVolume(t *testing.T) {
 		}, nil)
 		fsMock.On("GetUtil").Return(utilMock)
 
+		svc := service{
+			fs: fsMock,
+		}
+
 		err := svc.UnmountVolume(ctx, "", "/var/lib/dell/nfs/", map[string]string{
 			"ServiceName": "myNfsMount",
 		})
@@ -288,6 +290,9 @@ func TestUnmountVolume(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
+		utilMock := new(mocks.UtilInterface)
+		fsMock := new(mocks.FsInterface)
+
 		mockNode := mocks.NewMockInterface(ctrl)
 		oldRemove := osRemove
 		oldUnmount := sysUnmount
@@ -313,6 +318,10 @@ func TestUnmountVolume(t *testing.T) {
 		mockNode.EXPECT().NodeUnstageVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&csi.NodeUnstageVolumeResponse{}, nil)
 		PutNodeService(mockNode)
 
+		svc := service{
+			fs: fsMock,
+		}
+
 		err := svc.UnmountVolume(ctx, "123", "/var/lib/dell/nfs/", map[string]string{
 			"ServiceName": "myNfsMount",
 		})
@@ -320,6 +329,9 @@ func TestUnmountVolume(t *testing.T) {
 	})
 
 	t.Run("remove fail", func(t *testing.T) {
+		utilMock := new(mocks.UtilInterface)
+		fsMock := new(mocks.FsInterface)
+
 		mockNode := mocks.NewMockInterface(ctrl)
 		oldRemove := osRemove
 		oldUnmount := sysUnmount
@@ -345,6 +357,10 @@ func TestUnmountVolume(t *testing.T) {
 		mockNode.EXPECT().NodeUnstageVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&csi.NodeUnstageVolumeResponse{}, nil)
 		PutNodeService(mockNode)
 
+		svc := service{
+			fs: fsMock,
+		}
+
 		err := svc.UnmountVolume(ctx, "123", "/var/lib/dell/nfs/", map[string]string{
 			"ServiceName": "myNfsMount",
 		})
@@ -352,6 +368,9 @@ func TestUnmountVolume(t *testing.T) {
 	})
 
 	t.Run("unstage error", func(t *testing.T) {
+		utilMock := new(mocks.UtilInterface)
+		fsMock := new(mocks.FsInterface)
+
 		mockNode := mocks.NewMockInterface(ctrl)
 		oldRemove := osRemove
 		oldUnmount := sysUnmount
@@ -377,6 +396,10 @@ func TestUnmountVolume(t *testing.T) {
 		mockNode.EXPECT().NodeUnstageVolume(gomock.Any(), gomock.Any()).AnyTimes().Return(&csi.NodeUnstageVolumeResponse{}, errors.New("unstage error"))
 		PutNodeService(mockNode)
 
+		svc := service{
+			fs: fsMock,
+		}
+
 		err := svc.UnmountVolume(ctx, "123", "/var/lib/dell/nfs/", map[string]string{
 			"ServiceName": "myNfsMount",
 		})
@@ -384,6 +407,9 @@ func TestUnmountVolume(t *testing.T) {
 	})
 
 	t.Run("unable to determine mounts", func(t *testing.T) {
+		utilMock := new(mocks.UtilInterface)
+		fsMock := new(mocks.FsInterface)
+
 		oldRemove := osRemove
 		oldUnmount := sysUnmount
 		defer func() {
@@ -399,6 +425,10 @@ func TestUnmountVolume(t *testing.T) {
 		}
 		sysUnmount = func(_ string, _ int) error {
 			return nil
+		}
+
+		svc := service{
+			fs: fsMock,
 		}
 
 		err := svc.UnmountVolume(ctx, "123", "/var/lib/dell/nfs/", map[string]string{

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -23,11 +23,13 @@ import (
 	"time"
 
 	"github.com/dell/csi-powerstore/v2/pkg/common"
+	"github.com/dell/csi-powerstore/v2/pkg/common/fs"
 	"github.com/dell/csi-powerstore/v2/pkg/controller"
 	"github.com/dell/csi-powerstore/v2/pkg/node"
 	"github.com/dell/csm-hbnfs/nfs"
 	"github.com/dell/gocsi"
 	csictx "github.com/dell/gocsi/context"
+	"github.com/dell/gofsutil"
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -55,10 +57,13 @@ var (
 
 type service struct {
 	mode string
+	fs   fs.Interface
 }
 
 func New() nfs.Service {
-	return &service{}
+	return &service{
+		fs: &fs.Fs{Util: &gofsutil.FS{}},
+	}
 }
 
 func (s *service) BeforeServe(ctx context.Context, sp *gocsi.StoragePlugin, lis net.Listener) error {


### PR DESCRIPTION
# Description
Fix detection of mounted Shared NFS volumes and only try to unmount them if they do exist.

**Note:** Pending on merging of https://github.com/dell/csm-hbnfs/pull/25.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Test reassignment when a node goes down (reboot/shutdown) and clearing of exports/mounts when the node comes back up.
- [x] Ensure that normal deletion of Shared NFS exports/mounts are cleared.
