### PR TITLE
Remove sharednfs codes that starts node monitor services that affects performance

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -89,7 +89,7 @@ func (s *service) BeforeServe(ctx context.Context, _ *gocsi.StoragePlugin, _ net
 		return err
 	}
 
-	// The block is commented out for performance issue caused by sharednfs.
+	// The block is commented out for performance issue caused by sharednfs even when it's disabled.
 	// Remove the comment when enabling sharednfs feature.
 	/*
 		err = nfssvc.BeforeServe(ctx, sp, lis)


### PR DESCRIPTION
# Description
The PR comments out csm-sharednfs codes that starts node monitor services that affects performance. This commented block needs to be re-enabled later for sharednfs feature.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1930|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Unit test:
```
# make test
cd ./pkg; go test -race -cover -coverprofile=coverage.out ./...
ok      github.com/dell/csi-powerstore/v2/pkg/array     1.414s  coverage: 96.1% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/common    3.233s  coverage: 96.1% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/common/fs 1.150s  coverage: 90.6% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/common/k8sutils   2.092s  coverage: 90.8% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/controller        2.100s  coverage: 90.5% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/identity  1.128s  coverage: 100.0% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/interceptors      3.968s  coverage: 90.1% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/node      4.168s  coverage: 90.1% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/provider  1.204s  coverage: 100.0% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/service   1.186s  coverage: 94.4% of statements
ok      github.com/dell/csi-powerstore/v2/pkg/tracer    1.124s  coverage: 100.0% of statements
```
- Integration test:
```
 # ./cert-csi certify --cert-config samples/powerstore-certify-config.yaml --ns powerstore --nm
....
[-----------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-06-28 08:03:23]  INFO Avg time of a run:   57.29s
[2025-06-28 08:03:23]  INFO Avg time of a del:   16.77s
[2025-06-28 08:03:23]  INFO Avg time of all:     74.14s
[2025-06-28 08:03:23]  INFO During this run 100.0% of suites succeeded
```