### PR TITLE
Update gocsi for refactored utils pkg names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,14 +8,14 @@ require (
 	github.com/akutz/gosync v0.1.0
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/container-storage-interface/spec v1.6.0
-	github.com/dell/csi-metadata-retriever v1.11.1-0.20250609125910-c5c6a0a1f521
+	github.com/dell/csi-metadata-retriever v1.11.1-0.20250718153414-fd2c3f002226
 	github.com/dell/csm-sharednfs v1.0.0
 	github.com/dell/dell-csi-extensions/common v1.8.1-0.20250514175456-5ddd200c5e5c
 	github.com/dell/dell-csi-extensions/podmon v1.8.0
 	github.com/dell/dell-csi-extensions/replication v1.11.0
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.8.1
 	github.com/dell/gobrick v1.14.1-0.20250624004701-1c68c8c05f2f
-	github.com/dell/gocsi v1.14.1-0.20250701150109-1da4fb20c6c5
+	github.com/dell/gocsi v1.14.1-0.20250717201424-c79f876a35fe
 	github.com/dell/gofsutil v1.19.0
 	github.com/dell/goiscsi v1.12.0
 	github.com/dell/gonvme v1.11.1-0.20250701150147-3adc18df98ba

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dell/csi-metadata-retriever v1.11.1-0.20250609125910-c5c6a0a1f521 h1:eQlMjB+lYR7DuBR/WtjHG+E7ROIFUYLVys9bNdLl+yI=
-github.com/dell/csi-metadata-retriever v1.11.1-0.20250609125910-c5c6a0a1f521/go.mod h1:ZMDh47pc2rNob+qTUOtv17nR5CtpO0i35bQR5B2+DPk=
+github.com/dell/csi-metadata-retriever v1.11.1-0.20250718153414-fd2c3f002226 h1:J3pyPMRZSVZsqWd23yq/C//3hCOSmEnzqLxiyrlPaXQ=
+github.com/dell/csi-metadata-retriever v1.11.1-0.20250718153414-fd2c3f002226/go.mod h1:EEPFcVCYiJ4CAWy0+N7ypVeRgpdb7u3n+nlfOQkmZN4=
 github.com/dell/csm-sharednfs v1.0.0 h1:+sVJSU1q8i9lfHuSxJUYjQeofsWPcLfyY05m3x2CeWE=
 github.com/dell/csm-sharednfs v1.0.0/go.mod h1:+flf+ETu0LkNUDVFEybV7fJtO6MEHedg816CILTrXhs=
 github.com/dell/dell-csi-extensions/common v1.8.1-0.20250514175456-5ddd200c5e5c h1:FFYqKddDMmaLzsVth8OOc83TyS7u4OcCj2YcKPHKj2k=
@@ -113,8 +113,8 @@ github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.8.1 h1:NnS/P2OpwMlQ70
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.8.1/go.mod h1:rlJGlmp1NI8gU52HYKY2cy13TbSWvt9p5VAG2RLbkQs=
 github.com/dell/gobrick v1.14.1-0.20250624004701-1c68c8c05f2f h1:u2zZw6k1GhapS1ex8PyfZtIBTRldF3kHTxxLVM5xxSU=
 github.com/dell/gobrick v1.14.1-0.20250624004701-1c68c8c05f2f/go.mod h1:ML2lu6+tPdLeE+4eF/+Fytl/C8Ekce2qT/AKijjXqFs=
-github.com/dell/gocsi v1.14.1-0.20250701150109-1da4fb20c6c5 h1:oYexrwxjXsVh/XkpYx3kPZogAitO8Uq4hlzXrl30UH8=
-github.com/dell/gocsi v1.14.1-0.20250701150109-1da4fb20c6c5/go.mod h1:pzoyfeOJy5+FZ/uYxCO08MWai/qWtTSSNUfHrhm9/vI=
+github.com/dell/gocsi v1.14.1-0.20250717201424-c79f876a35fe h1:PYK4WxFpgGwofB/WrZWiW0HPd17h+DSJ8NVrcU5Acoc=
+github.com/dell/gocsi v1.14.1-0.20250717201424-c79f876a35fe/go.mod h1:pzoyfeOJy5+FZ/uYxCO08MWai/qWtTSSNUfHrhm9/vI=
 github.com/dell/gofsutil v1.19.0 h1:41Hx24Tlie37UbOwatHgNAV0nq+KQysrhABXCnpOs+E=
 github.com/dell/gofsutil v1.19.0/go.mod h1:yOuHhBa+iI/QXhZGm7BgCEdf+ji1nIFXzkObv1x0SRs=
 github.com/dell/goiscsi v1.12.0 h1:hxY9SaJLS/WQiDKQ9Vplguvg6jcF8wqTFGk5VzgFVj8=

--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -40,7 +40,7 @@ import (
 	"github.com/dell/csi-powerstore/v2/pkg/identifiers/fs"
 	"github.com/dell/gobrick"
 	csictx "github.com/dell/gocsi/context"
-	"github.com/dell/gocsi/utils"
+	csiutils "github.com/dell/gocsi/utils/csi"
 	"github.com/dell/gopowerstore"
 	log "github.com/sirupsen/logrus"
 )
@@ -207,7 +207,7 @@ type TransportType string
 
 // RmSockFile removes socket files that left after previous installation
 func RmSockFile(f fs.Interface) {
-	proto, addr, err := utils.GetCSIEndpoint()
+	proto, addr, err := csiutils.GetCSIEndpoint()
 	if err != nil {
 		log.Errorf("Error: failed to get CSI endpoint: %s\n", err.Error())
 	}

--- a/pkg/identifiers/identifiers_test.go
+++ b/pkg/identifiers/identifiers_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/dell/csi-powerstore/v2/mocks"
 	"github.com/dell/csi-powerstore/v2/pkg/identifiers"
 	csictx "github.com/dell/gocsi/context"
-	"github.com/dell/gocsi/utils"
+	csiutils "github.com/dell/gocsi/utils/csi"
 	"github.com/dell/gopowerstore"
 	gopowerstoremock "github.com/dell/gopowerstore/mocks"
 	log "github.com/sirupsen/logrus"
@@ -50,7 +50,7 @@ func TestCustomLogger(_ *testing.T) {
 func TestRmSockFile(t *testing.T) {
 	sockPath := "unix:///var/run/csi/csi.sock"
 	trimmedSockPath := "/var/run/csi/csi.sock"
-	_ = os.Setenv(utils.CSIEndpoint, sockPath)
+	_ = os.Setenv(csiutils.CSIEndpoint, sockPath)
 
 	t.Run("removed socket", func(_ *testing.T) {
 		fsMock := new(mocks.FsInterface)
@@ -84,7 +84,7 @@ func TestRmSockFile(t *testing.T) {
 
 	t.Run("no endpoint set", func(_ *testing.T) {
 		fsMock := new(mocks.FsInterface)
-		_ = os.Setenv(utils.CSIEndpoint, "")
+		_ = os.Setenv(csiutils.CSIEndpoint, "")
 
 		identifiers.RmSockFile(fsMock)
 	})

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	csictx "github.com/dell/gocsi/context"
-	mwtypes "github.com/dell/gocsi/middleware/serialvolume/types"
+	mwtypes "github.com/dell/gocsi/middleware/serialvolume/lockprovider"
 	log "github.com/sirupsen/logrus"
 	xctx "golang.org/x/net/context"
 

--- a/pkg/interceptors/interceptors_test.go
+++ b/pkg/interceptors/interceptors_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import (
 	controller "github.com/dell/csi-powerstore/v2/pkg/controller"
 	"github.com/dell/csi-powerstore/v2/pkg/identifiers"
 	csictx "github.com/dell/gocsi/context"
-	"github.com/dell/gocsi/middleware/serialvolume/types"
+	lockprovider "github.com/dell/gocsi/middleware/serialvolume/lockprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
@@ -210,7 +210,7 @@ func TestCreateMetadataRetrieverClient(t *testing.T) {
 
 // Define the options struct
 type options struct {
-	locker                types.VolumeLockerProvider
+	locker                lockprovider.VolumeLockerProvider
 	MetadataSidecarClient MetadataSidecarClient
 	timeout               time.Duration
 }


### PR DESCRIPTION
# Description
Updated gocsi commit to include the refactored utils package names.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# Testing:

cert-csi test suites have passed.

```
[root@master-1-gMLffggcEYiL6 cert-csi]# ./cert-csi certify --cert-config powerstore-config.yaml --vsc powerstore-snapshot
[2025-07-18 15:38:51]  INFO Starting cert-csi; ver. 1.8.0
...
[2025-07-18 15:38:51]  INFO 1. VolumeIoSuite {volumes: 2, volumeSize: 5Gi chains: 2-2}
[2025-07-18 15:38:51]  INFO 2. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 5Gi}
[2025-07-18 15:38:51]  INFO 3. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 5Gi}
[2025-07-18 15:38:51]  INFO 4. VolumeExpansionSuite {pods: 1, volumes: 1, size: 5Gi, expSize: 10Gi, block: false}
[2025-07-18 15:38:51]  INFO 5. VolumeExpansionSuite {pods: 1, volumes: 1, size: 5Gi, expSize: 10Gi, block: true}
[2025-07-18 15:38:51]  INFO 6. SnapSuite {snapshots: 3, volumeSize; 5Gi}
[2025-07-18 15:38:51]  INFO 7. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 5Gi}
[2025-07-18 15:38:51]  INFO 8. MultiAttachSuite {pods: 5, rawBlock: true, size: 5Gi, accMode: ReadWriteMany}
[2025-07-18 15:38:51]  INFO 9. MultiAttachSuite {pods: 5, rawBlock: false, size: 5Gi, accMode: ReadWriteOncePod}
[2025-07-18 15:38:51]  INFO 10. EphemeralVolumeSuite {driver: csi-powerstore.dellemc.com, podNumber: 2, volAttributes: map[arrayID:<ID>protocol:iSCSI size:5Gi]}
...
[2025-07-18 15:42:08]  INFO Avg time of a run:   67.18s
[2025-07-18 15:42:08]  INFO Avg time of a del:   29.75s
[2025-07-18 15:42:08]  INFO Avg time of all:     100.26s
[2025-07-18 15:42:08]  INFO During this run 100.0% of suites succeeded
```