### PR TITLE
Updated volume prefix handling

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -2283,14 +2283,15 @@ func ExtractPort(urlString string) (string, error) {
 func removeVolumePrefixFromName(volumeName string) string {
 	// Remove the tenant-prefix (Auth v2) from the volume name if exists so that the mount will not fail
 	extracted := ""
-	if strings.HasPrefix(volumeName, "csivol") {
+	volPrefix := os.Getenv("X_CSI_VOL_PREFIX") // We will read the volume-prefix set by the user from the env variable
+	if strings.HasPrefix(volumeName, volPrefix) {
 		extracted = volumeName
 	} else {
-		index := strings.Index(volumeName, "csivol")
+		index := strings.Index(volumeName, volPrefix)
 		if index != -1 {
 			extracted = volumeName[index:]
 		} else {
-			log.Info("'csivol' not found in the volume name.")
+			log.Info(volPrefix + ":not found in the volume name.")
 		}
 	}
 	return extracted

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -2281,18 +2281,11 @@ func ExtractPort(urlString string) (string, error) {
 }
 
 func removeVolumePrefixFromName(volumeName string) string {
-	// Remove the tenant-prefix (Auth v2) from the volume name if exists so that the mount will not fail
-	extracted := ""
-	volPrefix := os.Getenv("X_CSI_VOL_PREFIX") // We will read the volume-prefix set by the user from the env variable
-	if strings.HasPrefix(volumeName, volPrefix) {
-		extracted = volumeName
-	} else {
-		index := strings.Index(volumeName, volPrefix)
-		if index != -1 {
-			extracted = volumeName[index:]
-		} else {
-			log.Info(volPrefix + ":not found in the volume name.")
-		}
+	// Remove the tenant-prefix (Auth v2) from the volume name if exists so that the mount will not fail	
+	volPrefix := os.Getenv("X_CSI_VOL_PREFIX") // We will read the volume-prefix set by the user from the env variable	
+	lastIndex := strings.LastIndex(volumeName, volPrefix)
+	if lastIndex != -1 {
+		return volumeName[lastIndex:]
 	}
-	return extracted
+	return ""
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -2285,6 +2285,7 @@ func removeVolumePrefixFromName(volumeName string) string {
 	extracted := ""
 	if strings.HasPrefix(volumeName, "csivol") {
 		log.Debugf("The volume name starts with 'csivol':%s", volumeName)
+		extracted = volumeName
 	} else {
 		index := strings.Index(volumeName, "csivol")
 		if index != -1 {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -936,22 +936,17 @@ func (s *Service) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 	}
 
 	isBlock := strings.Contains(targetPath, blockVolumePathMarker)
-	log.Info("=====NodeExpandVolume called with parameters: ")
-	fmt.Println("=====NodeExpandVolume called with parameters: ")
 	// Parse the CSI VolumeId and validate against the volume
 	vol, err := arr.Client.GetVolume(ctx, id)
 	if err != nil {
 		// If the volume isn't found, we cannot stage it
 		return nil, status.Error(codes.NotFound, "Volume not found")
 	}
-	log.Info("=====Volume found: ", vol.Name)
-	fmt.Println("=====Volume found: ", vol.Name)
 
 	// If the volume is created from Auth v2 using a prefix then we need to remove that while publishing, otherwise mount will fail
 	finalVolName := removeVolumePrefixFromName(vol.Name)
-	fmt.Println("=====Final Volume Name: ", finalVolName)
-	log.Info("=====Final Volume Name: ", finalVolName)
 	vol.Name = finalVolName
+	log.Debug("Volume name after trimming: ", vol.Name)
 
 	volumeWWN := vol.Wwn
 
@@ -2289,14 +2284,13 @@ func removeVolumePrefixFromName(volumeName string) string {
 	// Remove the tenant-prefix (Auth v2) from the volume name if exists so that the mount will not fail
 	extracted := ""
 	if strings.HasPrefix(volumeName, "csivol") {
-		fmt.Println("The string starts with 'csivol':", volumeName)
+		log.Debugf("The string starts with 'csivol':%s", volumeName)
 	} else {
 		index := strings.Index(volumeName, "csivol")
 		if index != -1 {
 			extracted = volumeName[index:]
-			fmt.Println("Extracted from 'csivol':", extracted)
 		} else {
-			fmt.Println("'csivol' not found in the string.")
+			log.Info("'csivol' not found in the volume name.")
 		}
 	}
 	return extracted

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -2281,8 +2281,8 @@ func ExtractPort(urlString string) (string, error) {
 }
 
 func removeVolumePrefixFromName(volumeName string) string {
-	// Remove the tenant-prefix (Auth v2) from the volume name if exists so that the mount will not fail	
-	volPrefix := os.Getenv("X_CSI_VOL_PREFIX") // We will read the volume-prefix set by the user from the env variable	
+	// Remove the tenant-prefix (Auth v2) from the volume name if exists so that the mount will not fail
+	volPrefix := os.Getenv("X_CSI_VOL_PREFIX") // We will read the volume-prefix set by the user from the env variable
 	lastIndex := strings.LastIndex(volumeName, volPrefix)
 	if lastIndex != -1 {
 		return volumeName[lastIndex:]

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -2284,7 +2284,6 @@ func removeVolumePrefixFromName(volumeName string) string {
 	// Remove the tenant-prefix (Auth v2) from the volume name if exists so that the mount will not fail
 	extracted := ""
 	if strings.HasPrefix(volumeName, "csivol") {
-		log.Debugf("The volume name starts with 'csivol':%s", volumeName)
 		extracted = volumeName
 	} else {
 		index := strings.Index(volumeName, "csivol")

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -2284,7 +2284,7 @@ func removeVolumePrefixFromName(volumeName string) string {
 	// Remove the tenant-prefix (Auth v2) from the volume name if exists so that the mount will not fail
 	extracted := ""
 	if strings.HasPrefix(volumeName, "csivol") {
-		log.Debugf("The string starts with 'csivol':%s", volumeName)
+		log.Debugf("The volume name starts with 'csivol':%s", volumeName)
 	} else {
 		index := strings.Index(volumeName, "csivol")
 		if index != -1 {


### PR DESCRIPTION
# Description
Updated volume prefix handling when the volume is created from Auth v2 module
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1947 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested by running cert-csi volume expansion suite for both csi-powerstore with Auth v2 module and without Auth v2 module.
<img width="788" height="52" alt="image" src="https://github.com/user-attachments/assets/b9f5bb29-ac09-4f3c-9194-2d079dda5836" />

<img width="794" height="32" alt="image" src="https://github.com/user-attachments/assets/2251f2ac-bab9-47dd-b6a5-df8c0f69b2f7" />


<img width="535" height="20" alt="image" src="https://github.com/user-attachments/assets/f19f78f2-ecb9-4e5b-9113-28f2839c4319" />

With different volume prefix:
<img width="1391" height="126" alt="image (11)" src="https://github.com/user-attachments/assets/606e8f93-59ca-44eb-a6c4-ceb16c1e378c" />
