### PR TITLE
Usr/sreekb/configurable timeout array connectivity

### DIFF
--- a/pkg/controller/controller_node_to_array_connectivity.go
+++ b/pkg/controller/controller_node_to_array_connectivity.go
@@ -43,7 +43,6 @@ func (s *Service) QueryArrayStatus(ctx context.Context, url string) (bool, error
 		Timeout: identifiers.Timeout,
 	}
 
-	log.Infof("[Bharath-Debug] - Setting array connectivity timeout to %s", identifiers.Timeout.String())
 	resp, err := client.Get(url)
 
 	log.Debugf("Received response %+v for url %s", resp, url)

--- a/pkg/controller/controller_node_to_array_connectivity.go
+++ b/pkg/controller/controller_node_to_array_connectivity.go
@@ -42,6 +42,8 @@ func (s *Service) QueryArrayStatus(ctx context.Context, url string) (bool, error
 	client := http.Client{
 		Timeout: identifiers.Timeout,
 	}
+
+	log.Infof("[Bharath-Debug] - Setting array connectivity timeout to %s", identifiers.Timeout.String())
 	resp, err := client.Get(url)
 
 	log.Debugf("Received response %+v for url %s", resp, url)

--- a/pkg/identifiers/envvars.go
+++ b/pkg/identifiers/envvars.go
@@ -118,4 +118,7 @@ const (
 
 	// EnvDriverNamespace is the namespace where the powerstore driver is deployed
 	EnvDriverNamespace = "X_CSI_DRIVER_NAMESPACE"
+
+	// EnvDriverAPITimeout specifies the timeout for API calls
+	EnvDriverAPITimeout = "X_CSI_POWERSTORE_API_TIMEOUT"
 )

--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -195,12 +195,12 @@ const (
 	// DefaultPodmonPollRate is the default polling frequency to check for array connectivity
 	DefaultPodmonPollRate = 60
 
-	// Timeout for making http requests
-	Timeout = time.Second * 5
-
 	// ArrayStatus is the endPoint for polling to check array status
 	ArrayStatus = "/array-status"
 )
+
+// Timeout for making http requests
+var Timeout = getArrayConnectivityTimeout()
 
 // TransportType differentiates different SCSI transport protocols (FC, iSCSI, Auto, None)
 type TransportType string
@@ -550,4 +550,18 @@ func IsNFSServiceEnabled(ctx context.Context, client gopowerstore.Client) (bool,
 		}
 	}
 	return false, nil
+}
+
+func getArrayConnectivityTimeout() time.Duration {
+	if timeout, ok := csictx.LookupEnv(context.Background(), EnvDriverAPITimeout); ok {
+		log.Infof("[Bharath-Debug] timeout from env var read as %s", timeout)
+		duration, err := strconv.Atoi(timeout)
+		if err != nil {
+			log.Infof("[Bharath-Debug] invalid timeout specified, returning default")
+			return time.Second * 5
+		}
+		log.Infof("[Bharath-Debug] timeout set to %d", duration)
+		return time.Second * time.Duration(duration)
+	}
+	return time.Second * 5
 }

--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -200,7 +200,7 @@ const (
 )
 
 // Timeout for making http requests
-var Timeout = getArrayConnectivityTimeout()
+var Timeout = GetArrayConnectivityTimeout()
 
 // TransportType differentiates different SCSI transport protocols (FC, iSCSI, Auto, None)
 type TransportType string
@@ -552,7 +552,7 @@ func IsNFSServiceEnabled(ctx context.Context, client gopowerstore.Client) (bool,
 	return false, nil
 }
 
-func getArrayConnectivityTimeout() time.Duration {
+func GetArrayConnectivityTimeout() time.Duration {
 	var timeout time.Duration = time.Second * 5
 	if duration, ok := csictx.LookupEnv(context.Background(), EnvDriverAPITimeout); ok {
 		duration, err := strconv.Atoi(duration)

--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -553,15 +553,15 @@ func IsNFSServiceEnabled(ctx context.Context, client gopowerstore.Client) (bool,
 }
 
 func getArrayConnectivityTimeout() time.Duration {
-	if timeout, ok := csictx.LookupEnv(context.Background(), EnvDriverAPITimeout); ok {
-		log.Infof("[Bharath-Debug] timeout from env var read as %s", timeout)
-		duration, err := strconv.Atoi(timeout)
+	var timeout time.Duration = time.Second * 5
+	if duration, ok := csictx.LookupEnv(context.Background(), EnvDriverAPITimeout); ok {
+		duration, err := strconv.Atoi(duration)
 		if err != nil {
-			log.Infof("[Bharath-Debug] invalid timeout specified, returning default")
-			return time.Second * 5
+			log.Infof("Setting default timeout for API request")
+		} else {
+			timeout = time.Second * time.Duration(duration)
 		}
-		log.Infof("[Bharath-Debug] timeout set to %d", duration)
-		return time.Second * time.Duration(duration)
 	}
-	return time.Second * 5
+	log.Infof("API request timeout: %s", timeout.String())
+	return timeout
 }

--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -552,6 +552,7 @@ func IsNFSServiceEnabled(ctx context.Context, client gopowerstore.Client) (bool,
 	return false, nil
 }
 
+// GetArrayConnectivityTimeout get array connectivity timeout from environment variable or sets default value
 func GetArrayConnectivityTimeout() time.Duration {
 	var timeout time.Duration = time.Second * 5
 	if duration, ok := csictx.LookupEnv(context.Background(), EnvDriverAPITimeout); ok {

--- a/pkg/identifiers/identifiers_test.go
+++ b/pkg/identifiers/identifiers_test.go
@@ -614,13 +614,6 @@ func TestGetArrayConnectivityTimeout(t *testing.T) {
 			setupFunc:    func() { os.Setenv("X_CSI_POWERSTORE_API_TIMEOUT", "abc") },
 			teardownFunc: func() { os.Unsetenv("X_CSI_POWERSTORE_API_TIMEOUT") },
 		},
-		// {
-		// 	name:         "env variable is set to negative value",
-		// 	envValue:     "-1",
-		// 	expected:     5 * time.Second,
-		// 	setupFunc:    func() { os.Setenv("X_CSI_POWERSTORE_API_TIMEOUT", "-1") },
-		// 	teardownFunc: func() { os.Unsetenv("X_CSI_POWERSTORE_API_TIMEOUT") },
-		// },
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description
Introduce environment variable controlled option for Powerstore REST API timeout.
(Corresponding changes are made to helm and operator to enable the same).

If the env var is unspecified, or specified incorrectly, the timeout is defaulted to 5s. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Manually tested deploying the driver and observing relevant logs. Update values/samples and confirm the dynamic change. 
- [ ] Unit tests
```
Coverage results:
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/interceptors is 90.1%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/cmd/csi-powerstore is 90.6%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/identifiers/k8sutils is 90.8%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/controller is 90.5%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/node is 90.1%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/array is 96.1%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/tracer is 100.0%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/identifiers is 95.9%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/provider is 100.0%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/service is 94.4%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/identifiers/fs is 91.7%, not lower than 90%
PASS: coverage for package github.com/dell/csi-powerstore/v2/pkg/identity is 100.0%, not lower than 90%
```
