### PR TITLE
Bugfix: removeVolumePrefixFromName

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -2296,9 +2296,9 @@ func ExtractPort(urlString string) (string, error) {
 func removeVolumePrefixFromName(volumeName string) string {
 	// Remove the tenant-prefix (Auth v2) from the volume name if exists so that the mount will not fail
 	volPrefix := os.Getenv("X_CSI_VOL_PREFIX") // We will read the volume-prefix set by the user from the env variable
-	lastIndex := strings.LastIndex(volumeName, volPrefix)
-	if lastIndex != -1 {
-		return volumeName[lastIndex:]
+	// if it's empty string or undefined, don't remove anything
+	if volPrefix == "" {
+		return volumeName
 	}
-	return ""
+	return strings.TrimPrefix(volumeName, volPrefix)
 }

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -7307,3 +7307,47 @@ func elementsMatch(a, b []string) bool {
 	}
 	return true
 }
+
+func TestRemoveVolumePrefixFromName(t *testing.T) {
+	tests := []struct {
+		name           string
+		volumeName     string
+		prefix         string
+		expectedResult string
+	}{
+		{
+			name:           "prefix exists",
+			volumeName:     "prefix-volume-name",
+			prefix:         "prefix-",
+			expectedResult: "volume-name",
+		},
+		{
+			name:           "prefix does not exist",
+			volumeName:     "volume-name",
+			prefix:         "prefix-",
+			expectedResult: "volume-name",
+		},
+		{
+			name:           "empty volume name",
+			volumeName:     "",
+			prefix:         "prefix-",
+			expectedResult: "",
+		},
+		{
+			name:           "empty prefix",
+			volumeName:     "volume-name",
+			prefix:         "",
+			expectedResult: "volume-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("X_CSI_VOL_PREFIX", tt.prefix)
+			result := removeVolumePrefixFromName(tt.volumeName)
+			if result != tt.expectedResult {
+				t.Errorf("removeVolumePrefixFromName() got = %v, want %v", result, tt.expectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
#531 introduced a bug with trimming prefixes. This PR handles that with a cleaner prefix-trim, and adds unit tests. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
See unit tests attached. It was also tested with an image built that has passed OCP E2E tests. 