### PR TITLE
Fix Metro Volume Expansion

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1428,7 +1428,7 @@ func (s *Service) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReque
 	}, nil
 }
 
-func isPausedMetroSession(ctx context.Context, metroSessionID string, arr *array.PowerStoreArray) (paused bool, err error) {
+func IsPausedMetroSession(ctx context.Context, metroSessionID string, arr *array.PowerStoreArray) (paused bool, err error) {
 	metroSession, err := arr.Client.GetReplicationSessionByID(ctx, metroSessionID)
 	if err != nil {
 		return false, fmt.Errorf("could not get metro replication session %s", metroSessionID)
@@ -1483,7 +1483,7 @@ func (s *Service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 		if vol.Size < requiredBytes {
 			if isMetro {
 				// must pause metro session before modifying the volume
-				_, err = isPausedMetroSession(ctx, vol.MetroReplicationSessionID, array)
+				_, err = IsPausedMetroSession(ctx, vol.MetroReplicationSessionID, array)
 				if err != nil {
 					return nil, status.Errorf(codes.Internal,
 						"failed to expand the volume, %s, because the metro replication session is not paused. please pause the metro replication session: %s",

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2952,7 +2952,7 @@ var _ = ginkgo.Describe("CSIControllerService", func() {
 				_, err := ctrlSvc.ControllerExpandVolume(context.Background(), req)
 
 				gomega.Expect(err).ToNot(gomega.BeNil())
-				gomega.Expect(err.Error()).To(gomega.ContainSubstring("metro replication session not in 'paused' state"))
+				gomega.Expect(err.Error()).To(gomega.ContainSubstring("Please pause the metro replication session manually"))
 			})
 		})
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -975,18 +975,18 @@ func (s *Service) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 	if remoteVolumeID != "" {
 		if vol.MetroReplicationSessionID == "" {
 			return nil, status.Errorf(codes.Internal,
-				"cannot expand volume %q: missing metro replication session ID", vol.Name)
+				"cannot expand volume %s: missing metro replication session ID", vol.Name)
 		}
 
 		state, err := controller.GetMetroSessionState(ctx, vol.MetroReplicationSessionID, arr)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal,
-				"cannot expand volume %q: failed to get metro session state: %v", vol.Name, err)
+				"cannot expand volume %s: failed to get metro session state: %v", vol.Name, err)
 		}
 
 		if state != gopowerstore.RsStateOk {
 			return nil, status.Errorf(codes.Aborted,
-				"cannot expand volume %q: metro session %s is in state %q; expected 'OK'",
+				"cannot expand volume %s: metro session %s is not active, its in %s state",
 				vol.Name, vol.MetroReplicationSessionID, state)
 		}
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -971,8 +971,28 @@ func (s *Service) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 
 	if err != nil {
 		if isBlock {
+			// Stop block volume expansion if metro session is paused
+			// User needs to require resume first.
+			remoteVolumeID := volumeHandle.RemoteUUID // metro indicator
+			if remoteVolumeID != "" {
+				if vol.MetroReplicationSessionID == "" {
+					return nil, status.Errorf(codes.FailedPrecondition,
+						"cannot expand volume %q: missing metro replication session ID", vol.Name)
+				}
+				paused, err := controller.IsPausedMetroSession(ctx, vol.MetroReplicationSessionID, arr)
+				if err != nil {
+					return nil, status.Errorf(codes.Internal,
+						"cannot verify metro session for %q: %v", vol.Name, err) // unknown state → don't proceed
+				}
+				if paused {
+					return nil, status.Errorf(codes.FailedPrecondition,
+						"cannot expand volume %q: metro session %s is paused; resume and retry",
+						vol.Name, vol.MetroReplicationSessionID) // user need to manually resume the session
+				}
+			}
 			return s.nodeExpandRawBlockVolume(ctx, volumeWWN)
 		}
+
 		log.Infof("Failed to find mount info for (%s) with error (%s)", vol.Name, err.Error())
 		log.Info("Probably offline volume expansion. Will try to perform a temporary mount.")
 		var disklocation string

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -977,15 +977,10 @@ func (s *Service) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 			return nil, status.Errorf(codes.Internal,
 				"cannot expand volume %q: missing metro replication session ID", vol.Name)
 		}
-		paused, err := controller.IsPausedMetroSession(ctx, vol.MetroReplicationSessionID, arr)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal,
-				"cannot verify metro session for %q: %v", vol.Name, err) // unknown state → don't proceed
-		}
-		if paused {
+		if controller.IsPausedMetroSession(ctx, vol.MetroReplicationSessionID, arr) {
 			return nil, status.Errorf(codes.Aborted,
-				"cannot expand volume %q: metro session %s is paused; resume and retry",
-				vol.Name, vol.MetroReplicationSessionID) // user need to manually resume the session
+				"cannot expand volume %q: metro session %s is paused; resume it manually",
+				vol.Name, vol.MetroReplicationSessionID)
 		}
 	}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -970,11 +970,11 @@ func (s *Service) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 	}
 
 	// Stop block volume expansion if metro session is paused
-	// User needs to require resume first.
+	// User needs to resume it first.
 	remoteVolumeID := volumeHandle.RemoteUUID // metro indicator
 	if remoteVolumeID != "" {
 		if vol.MetroReplicationSessionID == "" {
-			return nil, status.Errorf(codes.FailedPrecondition,
+			return nil, status.Errorf(codes.Internal,
 				"cannot expand volume %q: missing metro replication session ID", vol.Name)
 		}
 		paused, err := controller.IsPausedMetroSession(ctx, vol.MetroReplicationSessionID, arr)
@@ -983,7 +983,7 @@ func (s *Service) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 				"cannot verify metro session for %q: %v", vol.Name, err) // unknown state → don't proceed
 		}
 		if paused {
-			return nil, status.Errorf(codes.FailedPrecondition,
+			return nil, status.Errorf(codes.Aborted,
 				"cannot expand volume %q: metro session %s is paused; resume and retry",
 				vol.Name, vol.MetroReplicationSessionID) // user need to manually resume the session
 		}


### PR DESCRIPTION
# Description
Refactored metro session check by introducing GetMetroSessionState. Controller and Node volume expansion now validate metro session state before and after expansion.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/2002 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Expanded Metro Volumes on Ubuntu
- [x] Expanded Metro Volumes on RHEL
- [x] Expanded Non-Metro Volumes Successfully 
