### PR TITLE
Remove ProtectionPolicy from volume when deleting

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -695,6 +695,15 @@ func (s *Service) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest
 			log.Debugf("Expected metro session for volume %s, but it seems to have been already removed.", id)
 		}
 
+		if volume.ProtectionPolicyID != "" {
+			_, err = arr.GetClient().ModifyVolume(ctx, &gopowerstore.VolumeModify{
+				ProtectionPolicyID: "",
+			}, volume.ID)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "failure removing protection policy on volume: %s", err.Error())
+			}
+		}
+
 		// Delete volume
 		_, err = arr.GetClient().DeleteVolume(ctx, nil, id)
 		if err == nil {


### PR DESCRIPTION
# Description
Since you can't delete a volume that has ProtectionPolicy it should be removed from the volume when deleting.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have executed the openshift end-to-end test scenarios without enabling any modules
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Not more than the unit testing
