### PR TITLE
fix: ipv6 connectivity on NVMeTCP

### DIFF
--- a/pkg/node/node_connectivity_checker.go
+++ b/pkg/node/node_connectivity_checker.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -314,9 +315,13 @@ func (s *Service) populateTargetsInCache(array *array.PowerStoreArray) {
 			}
 
 			for _, address := range infoList {
-				nvmeIP := strings.Split(address.Portal, ":")
-				log.Info("Trying to discover NVMe target from portal ", nvmeIP[0])
-				nvmeTargets, err := s.nvmeLib.DiscoverNVMeTCPTargets(nvmeIP[0], false)
+				nvmeHost, _, err := net.SplitHostPort(address.Portal)
+				if err != nil {
+					log.WithFields(log.Fields{"portal": address.Portal, "error": err}).Error("couldn't parse NVMe portal")
+					continue
+				}
+				log.Info("Trying to discover NVMe target from portal ", nvmeHost)
+				nvmeTargets, err := s.nvmeLib.DiscoverNVMeTCPTargets(nvmeHost, false)
 				if err != nil {
 					log.Error("couldn't discover targets")
 					continue


### PR DESCRIPTION
# Description
When using the driver with NVMeTCP, connecting the array using IPv6 addresses fails.

This issue is caused by the following code: nvmeIP := strings.Split(address.Portal, ":").

The current approach of splitting the address and port does not work for IPv6 addresses because they contain multiple : characters.